### PR TITLE
Add a method to check if a reimbursement is an exchange

### DIFF
--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -128,6 +128,14 @@ module Spree
       return_items.select(&:exchange_required?)
     end
 
+    def any_exchanges?
+      return_items.any?(&:exchange_processed?)
+    end
+
+    def all_exchanges?
+      return_items.all?(&:exchange_processed?)
+    end
+
     private
 
     def generate_number

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -161,6 +161,34 @@ describe Spree::Reimbursement do
     end
   end
 
+  describe "#all_exchanges?" do
+    it "returns true if all of the return items processed an exchange" do
+      return_items = [double(exchange_processed?: true), double(exchange_processed?: true)]
+      subject.stub(:return_items) { return_items }
+      expect(subject.all_exchanges?).to be true
+    end
+
+    it "returns false if any of the return items processed an exchange" do
+      return_items = [double(exchange_processed?: true), double(exchange_processed?: false)]
+      subject.stub(:return_items) { return_items }
+      expect(subject.all_exchanges?).to be false
+    end
+  end
+
+  describe "#any_exchanges?" do
+    it "returns true if any of the return items processed an exchange" do
+      return_items = [double(exchange_processed?: true), double(exchange_processed?: false)]
+      subject.stub(:return_items) { return_items }
+      expect(subject.any_exchanges?).to be true
+    end
+
+    it "returns false if none of the return items processed an exchange" do
+      return_items = [double(exchange_processed?: false), double(exchange_processed?: false)]
+      subject.stub(:return_items) { return_items }
+      expect(subject.any_exchanges?).to be false
+    end
+  end
+
   describe "#calculated_total" do
     context 'with return item amounts that would round up' do
       let(:reimbursement) { Spree::Reimbursement.new }


### PR DESCRIPTION
Allows us to check if a reimbursement is an exchange or a refund. This will be used in our refund mailer to the customer, but could be useful for other things too.