### PR TITLE
Add default price determination to price

### DIFF
--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -5,6 +5,7 @@ module Spree
 
     validate :check_price
     validates :amount, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+    after_save :set_default_price
 
     def display_amount
       money
@@ -50,5 +51,11 @@ module Spree
       price.to_d
     end
 
+    def set_default_price
+      if is_default?
+        other_default_prices = variant.prices.where(currency: self.currency, is_default: true).where.not(id: self.id)
+        other_default_prices.each { |p| p.update_attributes!(is_default: false) }
+      end
+    end
   end
 end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -20,7 +20,7 @@ module Spree
     has_many :images, -> { order(:position) }, as: :viewable, dependent: :destroy, class_name: "Spree::Image"
 
     has_one :default_price,
-      -> { where currency: Spree::Config[:currency] },
+      -> { where(currency: Spree::Config[:currency], is_default: true) },
       class_name: 'Spree::Price',
       dependent: :destroy
 
@@ -144,7 +144,7 @@ module Spree
     end
 
     def price_in(currency)
-      prices.select{ |price| price.currency == currency }.first || Spree::Price.new(variant_id: self.id, currency: currency)
+      prices.detect{ |price| price.currency == currency && price.is_default } || Spree::Price.new(variant_id: self.id, currency: currency)
     end
 
     def amount_in(currency)

--- a/core/db/migrate/20141231151320_add_default_column_to_price.rb
+++ b/core/db/migrate/20141231151320_add_default_column_to_price.rb
@@ -1,0 +1,5 @@
+class AddDefaultColumnToPrice < ActiveRecord::Migration
+  def change
+    add_column :spree_prices, :is_default, :boolean, default: true, null: false
+  end
+end

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -48,7 +48,6 @@ module Spree
         params = { email: 'test@test.com',
                    completed_at: Time.now,
                    line_items_attributes: line_items }
-
         order = Importer::Order.import(user,params)
         order.should be_completed
         order.state.should eq 'complete'

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -4,7 +4,7 @@ describe Spree::CreditCard do
   let(:valid_credit_card_attributes) do
     { :number => '4111111111111111',
       :verification_value => '123',
-      :expiry => "12 / 14",
+      :expiry => "12 / 15",
       :name => "Spree Commerce" }
   end
 
@@ -167,39 +167,39 @@ describe Spree::CreditCard do
   # Regression test for #3847 & #3896
   context "#expiry=" do
     it "can set with a 2-digit month and year" do
-      credit_card.expiry = '04 / 14'
+      credit_card.expiry = '04 / 15'
       expect(credit_card.month).to eq(4)
-      expect(credit_card.year).to eq(2014)
+      expect(credit_card.year).to eq(2015)
     end
 
     it "can set with a 2-digit month and 4-digit year" do
-      credit_card.expiry = '04 / 2014'
+      credit_card.expiry = '04 / 2015'
       expect(credit_card.month).to eq(4)
-      expect(credit_card.year).to eq(2014)
+      expect(credit_card.year).to eq(2015)
     end
 
     it "can set with a 2-digit month and 4-digit year without whitespace" do
-      credit_card.expiry = '04/14'
+      credit_card.expiry = '04/15'
       expect(credit_card.month).to eq(4)
-      expect(credit_card.year).to eq(2014)
+      expect(credit_card.year).to eq(2015)
     end
 
     it "can set with a 2-digit month and 4-digit year without whitespace" do
-      credit_card.expiry = '04/2014'
+      credit_card.expiry = '04/2015'
       expect(credit_card.month).to eq(4)
-      expect(credit_card.year).to eq(2014)
+      expect(credit_card.year).to eq(2015)
     end
 
     it "can set with a 2-digit month and 4-digit year without whitespace and slash" do
-      credit_card.expiry = '042014'
+      credit_card.expiry = '042015'
       expect(credit_card.month).to eq(4)
-      expect(credit_card.year).to eq(2014)
+      expect(credit_card.year).to eq(2015)
     end
 
     it "can set with a 2-digit month and 2-digit year without whitespace and slash" do
-      credit_card.expiry = '0414'
+      credit_card.expiry = '0415'
       expect(credit_card.month).to eq(4)
-      expect(credit_card.year).to eq(2014)
+      expect(credit_card.year).to eq(2015)
     end
 
     it "does not blow up when passed an empty string" do

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -17,7 +17,7 @@ describe Spree::Payment do
     Spree::CreditCard.create!(
       number: "4111111111111111",
       month: "12",
-      year: "2014",
+      year: "2015",
       verification_value: "123",
       name: "Name"
     )

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -189,6 +189,34 @@ describe Spree::Variant do
     end
   end
 
+  context "#default_price" do
+    context "when multiple prices are present in addition to a default price" do
+      before do
+        variant.prices << create(:price, :variant => variant, :currency => "USD", :amount => 12.12, :is_default => false)
+        variant.prices << create(:price, :variant => variant, :currency => "EUR", :amount => 29.99)
+        variant.prices << create(:price, :variant => variant, :currency => "EUR", :amount => 10.00, :is_default => false)
+        variant.reload
+      end
+
+      it "the default stays the same" do
+        variant.default_price.amount.should == 19.99
+      end
+
+      it "displays default price" do
+        variant.price_in("USD").display_amount.to_s.should == "$19.99"
+        variant.price_in("EUR").display_amount.to_s.should == "€29.99"
+      end
+    end
+
+    context "when adding multiple prices" do
+      it "it can reassign a default price" do
+        variant.default_price.amount.should == 19.99
+        variant.prices << create(:price, :variant => variant, :currency => "USD", :amount => 12.12)
+        variant.reload.default_price.amount.should == 12.12
+      end
+    end
+  end
+
   describe '.price_in' do
     before do
       variant.prices << create(:price, :variant => variant, :currency => "EUR", :amount => 33.33)

--- a/sample/db/samples/payments.rb
+++ b/sample/db/samples/payments.rb
@@ -12,7 +12,7 @@ end
 # reference it as such. Make it explicit here that this table has been renamed.
 Spree::CreditCard.table_name = 'spree_credit_cards'
 
-creditcard = Spree::CreditCard.create(:cc_type => 'visa', :month => 12, :year => 2014, :last_digits => '1111',
+creditcard = Spree::CreditCard.create(:cc_type => 'visa', :month => 12, :year => 2015, :last_digits => '1111',
                                       :name => 'Sean Schofield', :gateway_customer_profile_id => 'BGS-1234')
 
 Spree::Order.all.each_with_index do |order, index|


### PR DESCRIPTION
* Added is_default column to prices
* Change variant to apply default price to price where currency matches
  config currency and is_default is set to true
* Added after_save to determine if new price is set to is_default,
  former default price is no longer the default price

Also changed the exp for the credit cards in tests, as all cards 'expired' with the new year