### PR TITLE
Pull in i18n lockdown to fix specs

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'friendly_id', '5.0.3'
   s.add_dependency 'highline', '~> 1.6.18' # Necessary for the install generator
   s.add_dependency 'httparty', '~> 0.11' # For checking alerts.
+  s.add_dependency 'i18n', '0.6.9' # Lockdown to 0.6.9 since 0.6.10 breaks build https://github.com/svenfuchs/i18n/issues/259
   s.add_dependency 'json', '~> 1.7'
   s.add_dependency 'kaminari', '~> 0.15.0'
   s.add_dependency 'mail', '~> 2.5.4'


### PR DESCRIPTION
Pull in an i18n version lock from 2-2-stable to fix some failing specs.  2-2-stable has been locked at 0.6.9 for a while and spree-backend has switched back and forth between 0.6.x and 0.7.x a bunch.  It seems that the latest version of i18n breaks specs like these in spree_backend:

```
 1) Spree::ProductsController sets the default locale based off Spree::Frontend::Config[:locale]
Failure/Error: spree_get :index
I18n::InvalidLocale:
"de" is not a valid locale

# /home/travis/build/bonobos/spree/core/lib/spree/core/controller_helpers/common.rb:64:in `set_user_language'
# /home/travis/build/bonobos/spree/core/lib/spree/testing_support/controller_requests.rb:68:in `process_spree_action'
# /home/travis/build/bonobos/spree/core/lib/spree/testing_support/controller_requests.rb:30:in `spree_get'
# ./spec/controllers/controller_helpers_spec.rb:21:in `block (2 levels) in <top (required)>'

2) setting locale should be in french
Failure/Error: visit spree.root_path
I18n::InvalidLocale:
"fr" is not a valid locale

# /home/travis/build/bonobos/spree/core/lib/spree/core/controller_helpers/common.rb:64:in `set_user_language'
# ./spec/features/locale_spec.rb:20:in `block (2 levels) in <top (required)>'
```