### PR TITLE
Change 'pending' to 'skip' to fix spec failures

### DIFF
--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -121,7 +121,7 @@ describe Spree::Variant do
 
       context "with decimal comma" do
         it "captures the proper amount for a formatted price" do
-          pending "We are not interested in locales at this point"
+          skip "We are not interested in locales at this point"
           I18n.locale = :de
           variant.price = '1.599,99'
           variant.price.should == 1599.99
@@ -130,7 +130,7 @@ describe Spree::Variant do
 
       context "with a numeric price" do
         it "uses the price as is" do
-          pending "We are not interested in locales at this point"
+          skip "We are not interested in locales at this point"
           I18n.locale = :de
           variant.price = 1599.99
           variant.price.should == 1599.99
@@ -148,7 +148,7 @@ describe Spree::Variant do
 
       context "with decimal comma" do
         it "captures the proper amount for a formatted price" do
-          pending "We are not interested in locales at this point"
+          skip "We are not interested in locales at this point"
           I18n.locale = :de
           variant.cost_price = '1.599,99'
           variant.cost_price.should == 1599.99
@@ -157,7 +157,7 @@ describe Spree::Variant do
 
       context "with a numeric price" do
         it "uses the price as is" do
-          pending "We are not interested in locales at this point"
+          skip "We are not interested in locales at this point"
           I18n.locale = :de
           variant.cost_price = 1599.99
           variant.cost_price.should == 1599.99


### PR DESCRIPTION
From [rspec changelog](https://github.com/rspec/rspec-core/blob/master/Changelog.md#300beta2--2014-02-17) for version 3:

> An example group level pending block or :pending metadata now executes the example and cause a failure if it passes, otherwise it will be pending if it fails.