### PR TITLE
Only set address in order_params if the address is present

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -111,8 +111,8 @@ module Spree
             params[:order][:payments_attributes] = params[:order][:payments] if params[:order][:payments]
             params[:order][:shipments_attributes] = params[:order][:shipments] if params[:order][:shipments]
             params[:order][:line_items_attributes] = params[:order][:line_items] if params[:order][:line_items]
-            params[:order][:ship_address_attributes] = params[:order][:ship_address] if params[:order][:ship_address]
-            params[:order][:bill_address_attributes] = params[:order][:bill_address] if params[:order][:bill_address]
+            params[:order][:ship_address_attributes] = params[:order][:ship_address] if params[:order][:ship_address].present?
+            params[:order][:bill_address_attributes] = params[:order][:bill_address] if params[:order][:bill_address].present?
 
             params.require(:order).permit(permitted_order_attributes)
           else


### PR DESCRIPTION
If an order transitions to the address state but the user doesn't fill out any address information and then tries to add an item to their cart, they will not be able to. This is because empty addresses will be passed to the backend, which causes an error [here] (https://github.com/bonobos/spree/blob/2-2-dev/api/app/controllers/spree/api/orders_controller.rb#L62).

I think it would be best if the order's state went back to cart whenever an item is added or removed from an order, but I thought this would be better for a quick fix. Any opinions?