### PR TITLE
Show variants on stock management page even if there are no stock items

### DIFF
--- a/backend/app/views/spree/admin/products/stock.html.erb
+++ b/backend/app/views/spree/admin/products/stock.html.erb
@@ -27,66 +27,64 @@
   </thead>
   <tbody>
     <% @variants.each do |variant| %>
-      <% if variant.stock_items.present? %>
-        <tr id="<%= spree_dom_id variant %>" data-hook="admin_product_stock_management_index_rows" class="<%= cycle('odd', 'even') %>">
-          <td class="align-center">
-            <%= variant.sku_and_options_text %>
-            <br>
-            <% if variant.images.present? %>
-              <%= image_tag variant.images.first.attachment.url(:mini) %>
-            <% end %>
-            <br/>
-            <%= form_tag admin_product_variants_including_master_path(@product, variant, format: :js), method: :put, class: 'toggle_variant_track_inventory' do %>
-                <%= check_box_tag 'track_inventory', 1, variant.track_inventory?,
-                                  class: 'track_inventory_checkbox' %>
-                <%= Spree.t(:track_inventory) %>
-                <%= hidden_field_tag 'variant[track_inventory]', variant.track_inventory?,
-                    class: 'variant_track_inventory',
-                    id: "variant_track_inventory_#{variant.id}" %>
-            <% end %>
-          </td>
-          <td colspan="4" class="stock_location_info">
-            <table>
-              <colgroup>
-                <col style="width: 45%" />
-                <col style="width: 20%" />
-                <col style="width: 20%" />
-                <col style="width: 15%" />
-              </colgroup>
-              <thead>
-                <th><%= Spree.t(:stock_location) %></th>
-                <th><%= Spree.t(:count_on_hand) %></th>
-                <th><%= Spree.t(:backorderable) %></th>
-                <th class="actions"></th>
-              </thead>
-              <tbody>
-                <% variant.stock_items.each do |item| %>
-                  <% next unless @stock_locations.include?(item.stock_location) %>
+      <tr id="<%= spree_dom_id variant %>" data-hook="admin_product_stock_management_index_rows" class="<%= cycle('odd', 'even') %>">
+        <td class="align-center">
+          <%= variant.sku_and_options_text %>
+          <br>
+          <% if variant.images.present? %>
+            <%= image_tag variant.images.first.attachment.url(:mini) %>
+          <% end %>
+          <br/>
+          <%= form_tag admin_product_variants_including_master_path(@product, variant, format: :js), method: :put, class: 'toggle_variant_track_inventory' do %>
+              <%= check_box_tag 'track_inventory', 1, variant.track_inventory?,
+                                class: 'track_inventory_checkbox' %>
+              <%= Spree.t(:track_inventory) %>
+              <%= hidden_field_tag 'variant[track_inventory]', variant.track_inventory?,
+                  class: 'variant_track_inventory',
+                  id: "variant_track_inventory_#{variant.id}" %>
+          <% end %>
+        </td>
+        <td colspan="4" class="stock_location_info">
+          <table>
+            <colgroup>
+              <col style="width: 45%" />
+              <col style="width: 20%" />
+              <col style="width: 20%" />
+              <col style="width: 15%" />
+            </colgroup>
+            <thead>
+              <th><%= Spree.t(:stock_location) %></th>
+              <th><%= Spree.t(:count_on_hand) %></th>
+              <th><%= Spree.t(:backorderable) %></th>
+              <th class="actions"></th>
+            </thead>
+            <tbody>
+              <% variant.stock_items.each do |item| %>
+                <% next unless @stock_locations.include?(item.stock_location) %>
 
-                  <tr id="stock-item-<%= item.id %>" class="<%= cycle('odd', 'even', :name => 'stock_locations')%>">
-                    <td class="align-center"><%= item.stock_location.name %></td>
-                    <td class="align-center"><%= item.count_on_hand %></td>
-                    <td class="align-center">
-                      <%= form_tag admin_stock_item_path(item), method: :put, class: 'toggle_stock_item_backorderable' do %>
-                        <%= check_box_tag 'stock_item[backorderable]', true,
-                              item.backorderable?,
-                              class: 'stock_item_backorderable',
-                              id: "stock_item_backorderable_#{item.stock_location.id}" %>
-                      <% end %>
-                    </td>
-                    <td class="actions">
-                      <%= link_to(icon('delete'), [:admin, item],
-                            method: :delete, remote: true,
-                            class: 'icon_link with-tip fa fa-trash no-text',
-                            title: Spree.t(:remove), data: { action: :remove, confirm: Spree.t(:are_you_sure) }) %>
-                    </td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          </td>
-          <% reset_cycle("stock_locations") %>
-        <% end %>
+                <tr id="stock-item-<%= item.id %>" class="<%= cycle('odd', 'even', :name => 'stock_locations')%>">
+                  <td class="align-center"><%= item.stock_location.name %></td>
+                  <td class="align-center"><%= item.count_on_hand %></td>
+                  <td class="align-center">
+                    <%= form_tag admin_stock_item_path(item), method: :put, class: 'toggle_stock_item_backorderable' do %>
+                      <%= check_box_tag 'stock_item[backorderable]', true,
+                            item.backorderable?,
+                            class: 'stock_item_backorderable',
+                            id: "stock_item_backorderable_#{item.stock_location.id}" %>
+                    <% end %>
+                  </td>
+                  <td class="actions">
+                    <%= link_to(icon('delete'), [:admin, item],
+                          method: :delete, remote: true,
+                          class: 'icon_link with-tip fa fa-trash no-text',
+                          title: Spree.t(:remove), data: { action: :remove, confirm: Spree.t(:are_you_sure) }) %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </td>
+        <% reset_cycle("stock_locations") %>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
* Remove an if statement that wont show a variant if there are no stock items. It still paginates, so it makes the page look broken.