### PR TITLE
Allow payments with invalid sources to be invalidated

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -14,7 +14,7 @@ module Spree
     has_many :capture_events, :class_name => 'Spree::PaymentCaptureEvent'
     has_many :refunds, inverse_of: :payment
 
-    before_validation :validate_source
+    before_validation :validate_source, unless: :invalid?
     before_create :set_unique_identifier
 
     after_save :create_payment_profile, if: :profiles_supported?

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -100,6 +100,20 @@ describe Spree::Payment do
       payment.invalidate
       payment.state.should eq('invalid')
     end
+
+    context "the payment's source is invalid" do
+
+      before(:each) do
+        card.year = 2014
+        payment.source = card
+      end
+
+      it "transitions to invalid" do
+        payment.state = 'checkout'
+        payment.invalidate
+        payment.state.should eq ('invalid')
+      end
+    end
   end
 
   context "processing" do


### PR DESCRIPTION
If an order had a payment with an invalid payment_source, new payments could not be added to the order. This removes the source check if the payment is transitioning to the invalid state.