### PR TITLE
Give option to select ‘given to customer’ or ‘lost in transit’ when processing customer returns.

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -7,6 +7,10 @@
       <th><%= Spree.t(:preferred_reimbursement_type) %></th>
       <th><%= Spree.t(:exchange_for) %></th>
       <th><%= Spree.t(:acceptance_errors) %></th>
+      <th><%= Spree.t(:reception_status) %></th>
+      <% unless return_items.all?(&:received?)%>
+        <th><%= Spree.t(:item_received?) %></th>
+      <% end %>
       <% if show_decision %>
         <th class="actions"></th>
       <% end %>
@@ -34,6 +38,17 @@
         <td class="align-center">
           <%= return_item.acceptance_status_errors %>
         </td>
+        <td class-"align-center">
+          <%= return_item.reception_status.humanize %>
+        </td>
+        <% unless return_item.received? %>
+          <td class='align-center'>
+            <%= form_for [:admin, return_item] do |f| %>
+              <%= f.hidden_field 'reception_status', value: 'received' %>
+              <%= f.button Spree.t(:receive), class: 'fa icon_link no-text with-tip', "data-action" => 'save' %>
+            <% end %>
+          </td>
+        <% end %>
         <% if show_decision %>
           <td class='actions'>
             <%= form_for [:admin, return_item] do |f| %>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
@@ -9,6 +9,7 @@
       <th><%= Spree.t(:pre_tax_amount) %></th>
       <th><%= Spree.t(:exchange_for) %></th>
       <th><%= Spree.t(:resellable) %></th>
+      <th><%= Spree.t(:reception_status) %></th>
     </tr>
   </thead>
   <tbody>
@@ -22,7 +23,6 @@
             <%= item_fields.hidden_field :return_authorization_id %>
             <%= item_fields.hidden_field :pre_tax_amount %>
           </div>
-
           <%= item_fields.check_box :returned, {checked: false, class: 'add-item', "data-price" => return_item.pre_tax_amount}, '1', '0' %>
         </td>
         <td>
@@ -40,6 +40,9 @@
         </td>
         <td class="align-center">
           <%= item_fields.check_box :resellable, { checked: return_item.resellable } %>
+        </td>
+        <td class="align-center">
+          <%= item_fields.select :reception_status, return_item.available_active_status_paths.collect { |s| [s.to_s.humanize, s] }, {include_blank: false}, {class: 'add-item select2 fullwidth'} %>
         </td>
       </tr>
     <% end %>

--- a/backend/spec/features/admin/orders/line_items_spec.rb
+++ b/backend/spec/features/admin/orders/line_items_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 # Tests for #3958's features
 describe "Order Line Items", js: true do
   stub_authorization!
-  
+
   before do
     # Removing the delivery step causes the order page to render a different
     # partial, called _line_items, which shows line items rather than shipments

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -49,6 +49,10 @@ module Spree
       !return_items.undecided.exists?
     end
 
+    def return_order!
+      order.return! if order.all_inventory_units_returned?
+    end
+
     private
 
     def generate_number
@@ -59,8 +63,8 @@ module Spree
     end
 
     def process_return!
-      return_items.each(&:receive!)
-      order.return! if order.all_inventory_units_returned?
+      return_items.each(&:attempt_accept)
+      return_order!
     end
 
     def return_items_belong_to_same_order

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -1,6 +1,9 @@
 module Spree
   class ReturnItem < ActiveRecord::Base
-    COMPLETED_RECEPTION_STATUSES = %w(received given_to_customer)
+
+    define_attribute_methods = :reception_status
+
+    COMPLETED_RECEPTION_STATUSES = %i(received given_to_customer lost_in_transit)
 
     class_attribute :return_eligibility_validator
     self.return_eligibility_validator = ReturnItem::EligibilityValidator::DefaultEligibilityValidator
@@ -27,10 +30,12 @@ module Spree
     validate :validate_no_other_completed_return_items, on: :create
 
     after_create :cancel_others, unless: :cancelled?
+    after_save :receive_items
 
     scope :awaiting_return, -> { where(reception_status: 'awaiting') }
-    scope :received, -> { where(reception_status: 'received') }
     scope :not_cancelled, -> { where.not(reception_status: 'cancelled') }
+    scope :given_to_customer, -> { where(reception_status: 'given_to_customer') }
+    scope :lost_in_transit, -> { where(reception_status: 'lost_in_transit') }
     scope :pending, -> { where(acceptance_status: 'pending') }
     scope :accepted, -> { where(acceptance_status: 'accepted') }
     scope :rejected, -> { where(acceptance_status: 'rejected') }
@@ -54,11 +59,10 @@ module Spree
     before_save :set_exchange_pre_tax_amount
 
     state_machine :reception_status, initial: :awaiting do
-      after_transition to: :received, do: :attempt_accept
-      after_transition to: :received, do: :process_inventory_unit!
+      after_transition to: COMPLETED_RECEPTION_STATUSES,  do: :attempt_accept
 
       event :receive do
-        transition to: :received, from: :awaiting
+        transition to: :received, from: [:awaiting, :given_to_customer, :lost_in_transit]
       end
 
       event :cancel do
@@ -67,6 +71,10 @@ module Spree
 
       event :give do
         transition to: :given_to_customer, from: :awaiting
+      end
+
+      event :lost do
+        transition to: :lost_in_transit, from: :awaiting
       end
     end
 
@@ -150,7 +158,20 @@ module Spree
       self.pre_tax_amount = refund_amount_calculator.new.compute(self)
     end
 
+    def available_active_status_paths
+      status_paths = reception_status_paths.to_states
+      status_paths.delete(:cancelled)
+      status_paths
+    end
+
     private
+
+    def receive_items
+      if received? && reception_status_was != "received"
+        process_inventory_unit!
+        self.customer_return.return_order! if customer_return
+      end
+    end
 
     def persist_acceptance_status_errors
       self.update_attributes(acceptance_status_errors: validator.errors)

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -37,7 +37,7 @@ module Spree
 
     @@checkout_attributes = [:email, :use_billing, :shipping_method_id, :coupon_code, :special_instructions]
 
-    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :acceptance_status, :exchange_variant_id, :resellable]]
+    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :reception_status, :acceptance_status, :exchange_variant_id, :resellable]]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
 
@@ -71,7 +71,7 @@ module Spree
     # month / year may be provided by some sources, or others may elect to use one field
     @@source_attributes = [
       :number, :month, :year, :expiry, :verification_value,
-      :first_name, :last_name, :cc_type, :gateway_customer_profile_id, 
+      :first_name, :last_name, :cc_type, :gateway_customer_profile_id,
       :gateway_payment_profile_id, :last_digits, :name, :encrypted_data]
 
     @@stock_item_attributes = [:variant, :stock_location, :backorderable, :variant_id]

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -11,6 +11,7 @@ describe "exchanges:charge_unreturned_items" do
 
   context "there are unreturned items" do
     let!(:order) { create(:shipped_order, line_items_count: 2) }
+    let!(:customer_return) { build(:customer_return, return_items: [return_item_1, return_item_2]) }
     let(:return_item_1) { build(:exchange_return_item, inventory_unit: order.inventory_units.first) }
     let(:return_item_2) { build(:exchange_return_item, inventory_unit: order.inventory_units.last) }
     let!(:rma) { create(:return_authorization, order: order, return_items: [return_item_1, return_item_2]) }

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -155,11 +155,11 @@ describe Spree::CustomerReturn do
 
   context ".after_save" do
     let(:inventory_unit)  { create(:inventory_unit, state: 'shipped', order: create(:shipped_order)) }
-    let(:return_item)     { create(:return_item, inventory_unit: inventory_unit) }
+    let(:return_item)     { build(:return_item, reception_status: 'received', inventory_unit: inventory_unit) }
 
     context "to the initial stock location" do
 
-      it "should mark all inventory units are returned" do
+      it "should mark the received inventory units are returned" do
         create(:customer_return_without_return_items, return_items: [return_item], stock_location_id: inventory_unit.shipment.stock_location_id)
         expect(inventory_unit.reload.state).to eq 'returned'
       end
@@ -205,6 +205,24 @@ describe Spree::CustomerReturn do
         count_on_hand = inventory_unit.find_stock_item.count_on_hand
         create(:customer_return_without_return_items, return_items: [return_item], stock_location_id: new_stock_location.id)
         inventory_unit.find_stock_item.count_on_hand.should == count_on_hand
+      end
+    end
+
+    context "it was not received" do
+
+      before do
+        return_item.update_attributes!(reception_status: "lost_in_transit")
+      end
+
+      it 'should not updated inventory unit to returned' do
+        create(:customer_return_without_return_items, return_items: [return_item], stock_location_id: inventory_unit.shipment.stock_location_id)
+        expect(inventory_unit.reload.state).to eq 'shipped'
+      end
+
+      it "should not update the stock item counts in the stock location" do
+        expect do
+          create(:customer_return_without_return_items, return_items: [return_item], stock_location_id: inventory_unit.shipment.stock_location_id)
+        end.to_not change { inventory_unit.find_stock_item.count_on_hand }
       end
     end
   end

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -19,7 +19,9 @@ describe Spree::ReturnItem do
 
   describe '#receive!' do
     let(:now)            { Time.now }
-    let(:inventory_unit) { create(:inventory_unit, state: 'shipped') }
+    let(:order)          { create(:shipped_order)}
+    let(:inventory_unit) { create(:inventory_unit, order: order,state: 'shipped') }
+    let!(:customer_return) { create(:customer_return_without_return_items, return_items: [return_item], stock_location_id: inventory_unit.shipment.stock_location_id) }
     let(:return_item)    { create(:return_item, inventory_unit: inventory_unit) }
 
     before do
@@ -29,7 +31,6 @@ describe Spree::ReturnItem do
     end
 
     subject { return_item.receive! }
-
 
     it 'returns the inventory unit' do
       subject
@@ -43,7 +44,6 @@ describe Spree::ReturnItem do
 
     context 'with a stock location' do
       let(:stock_item)      { inventory_unit.find_stock_item }
-      let!(:customer_return) { create(:customer_return_without_return_items, return_items: [return_item], stock_location_id: inventory_unit.shipment.stock_location_id) }
 
       before do
         inventory_unit.update_attributes!(state: 'shipped')
@@ -81,8 +81,37 @@ describe Spree::ReturnItem do
           expect { subject }.to_not change { stock_item.reload.count_on_hand }
         end
       end
+
+      context 'when the item was given to customer' do
+        before { return_item.update_attributes!(reception_status: 'given_to_customer') }
+
+        it 'processes the inventory unit' do
+          subject
+          expect(return_item.inventory_unit.reload.state).to eq('returned')
+        end
+
+        it 'return remains accepted' do
+          subject
+          expect(return_item.acceptance_status).to eq('accepted')
+        end
+      end
+
+      context 'when the item was lost in transit' do
+        before { return_item.update_attributes!(reception_status: 'lost_in_transit') }
+
+        it 'processes the inventory unit' do
+          subject
+          expect(return_item.inventory_unit.reload.state).to eq('returned')
+        end
+
+        it 'return remains accepted' do
+          subject
+          expect(return_item.acceptance_status).to eq('accepted')
+        end
+      end
     end
   end
+
 
   describe "#display_pre_tax_amount" do
     let(:pre_tax_amount) { 21.22 }
@@ -178,10 +207,8 @@ describe Spree::ReturnItem do
       end
     end
 
-    (all_reception_statuses - ['awaiting']).each do |invalid_transition_status|
-      context "return_item has a reception status of #{invalid_transition_status}" do
-        it_behaves_like "an invalid state transition", invalid_transition_status, 'received'
-      end
+    context "return_item has a reception status of cancelled" do
+      it_behaves_like "an invalid state transition", 'cancelled', 'received'
     end
   end
 
@@ -208,25 +235,76 @@ describe Spree::ReturnItem do
   end
 
   describe "#give" do
-    let(:return_item) { create(:return_item, reception_status: status) }
+    let(:return_item) { create(:return_item, reception_status: 'given_to_customer', inventory_unit: inventory_unit) }
+    let(:inventory_unit) { create(:inventory_unit, state: 'shipped') }
 
     subject { return_item.give! }
 
     context "awaiting status" do
-      let(:status) { 'awaiting' }
+      before do
+        inventory_unit.update_attributes!(state: 'shipped')
+        return_item.update_attributes!(reception_status: 'awaiting')
+        return_item.stub(:eligible_for_return?).and_return(true)
+      end
 
-      before { subject }
+      it "attempts to accept the return" do
+        expect(return_item).to receive(:attempt_accept)
+        subject
+      end
+
+      it 'accepts the return' do
+        subject
+        expect(return_item.acceptance_status).to eq('accepted')
+      end
+
+      it 'does not decrease inventory' do
+        subject
+        expect(return_item).to_not receive(:process_inventory_unit)
+      end
 
       it "transitions successfully" do
+        subject
         expect(return_item).to be_given_to_customer
       end
     end
 
-    (all_reception_statuses - ['awaiting']).each do |invalid_transition_status|
-      context "return_item has a reception status of #{invalid_transition_status}" do
-        it_behaves_like "an invalid state transition", invalid_transition_status, 'give_to_customer'
+    it_behaves_like "an invalid state transition", 'cancelled', 'given_to_customer'
+  end
+
+  describe "#give" do
+    let(:return_item) { create(:return_item, reception_status: 'lost_in_transit', inventory_unit: inventory_unit) }
+    let(:inventory_unit) { create(:inventory_unit, state: 'shipped') }
+
+    subject { return_item.lost! }
+
+    context "awaiting status" do
+      before do
+        return_item.update_attributes!(reception_status: 'awaiting')
+        return_item.stub(:eligible_for_return?).and_return(true)
+      end
+
+      it "attempts to accept the return" do
+        expect(return_item).to receive(:attempt_accept)
+        subject
+      end
+
+      it 'accepts the return' do
+        subject
+        expect(return_item.acceptance_status).to eq('accepted')
+      end
+
+      it 'does not decrease inventory' do
+        subject
+        expect(return_item).to_not receive(:process_inventory_unit)
+      end
+
+      it "transitions successfully" do
+        subject
+        expect(return_item).to be_lost_in_transit
       end
     end
+
+    it_behaves_like "an invalid state transition", 'cancelled', 'given_to_customer'
   end
 
   describe "#attempt_accept" do


### PR DESCRIPTION
Added two new states to return items (given, lost) as a completed state; if a return item is given or lost, the inventory unit is not changed. An item can go from lost or given to received, which will update inventory. Backend customer return view now requires a choice selected determining the reception status.