### PR TITLE
Allow customer returns to be received to inactive stock locations. 

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -34,7 +34,7 @@
 
         <%= f.field_container :stock_location do %>
           <%= f.label :stock_location, Spree.t(:stock_location) %>
-          <%= f.select :stock_location_id, Spree::StockLocation.order_default.active.to_a.collect{|l|[l.name.humanize, l.id]}, {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
+          <%= f.select :stock_location_id, Spree::StockLocation.order_default.to_a.collect{|l|[l.name.humanize, l.id]}, {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
           <%= f.error_message_on :stock_location_id %>
         <% end %>
 

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -65,7 +65,6 @@ module Spree
     preference :customer_returns_per_page, :integer, default: 15
     preference :redirect_https_to_http, :boolean, :default => false
     preference :require_master_price, :boolean, default: true
-    preference :restock_inventory, :boolean, default: true # Determines if a return item is restocked automatically once it has been received
     preference :return_eligibility_number_of_days, :integer, default: 365
     preference :shipment_inc_vat, :boolean, default: false
     preference :shipping_instructions, :boolean, default: false # Request instructions/info for shipping

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -233,7 +233,7 @@ module Spree
     end
 
     def should_restock?
-      variant.should_track_inventory? && stock_item && Spree::Config[:restock_inventory]
+      variant.should_track_inventory? && stock_item && stock_item.stock_location.restock_inventory?
     end
   end
 end

--- a/core/db/migrate/20150121202544_add_restock_inventory_to_stock_location.rb
+++ b/core/db/migrate/20150121202544_add_restock_inventory_to_stock_location.rb
@@ -1,0 +1,5 @@
+class AddRestockInventoryToStockLocation < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_locations, :restock_inventory, :boolean, default: true, null: false
+  end
+end

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -48,6 +48,7 @@ describe Spree::ReturnItem do
       before do
         inventory_unit.update_attributes!(state: 'shipped')
         return_item.update_attributes!(reception_status: 'awaiting')
+        stock_item.stock_location.update_attributes!(restock_inventory: true)
       end
 
       it 'increases the count on hand' do
@@ -66,9 +67,9 @@ describe Spree::ReturnItem do
         end
       end
 
-      context 'when the restock_inventory preference is false' do
+      context "when the stock location's restock_inventory is false" do
         before do
-          Spree::Config[:restock_inventory] = false
+          stock_item.stock_location.update_attributes!(restock_inventory: false)
         end
 
         it 'does not increase the count on hand' do


### PR DESCRIPTION
* Allow customer returns to be received to inactive stock locations
* Make restock_inventory a stock location specific flag, instead of application-level specific