### PR TITLE
Renaming find_current_order for ability to scope in extensions

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -149,7 +149,11 @@ module Spree
         end
 
         def find_current_order
-          current_api_user ? current_api_user.orders.incomplete.order(:created_at).last : nil
+          current_api_user ? find_current_api_user_orders.last : nil
+        end
+
+        def find_current_api_user_orders
+          current_api_user.orders.incomplete.order(:created_at)
         end
 
         def before_delivery


### PR DESCRIPTION
* We need to scope this by origin location as well as store, this will make it easier. 