### PR TITLE
Refactor admin/customer_details controller to use order contents

### DIFF
--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -21,8 +21,8 @@ module Spree
         def update
           if @order.contents.update_cart(order_params)
             if params[:guest_checkout] == "false"
-              requsted_user = Spree.user_class.find(params[:user_id])
-              @order.contents.associate_user(requsted_user, @order.email.blank?)
+              requested_user = Spree.user_class.find(params[:user_id])
+              @order.contents.associate_user(requested_user, @order.email.blank?)
             end
             @order.next
             @order.refresh_shipment_rates

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -19,12 +19,13 @@ module Spree
         end
 
         def update
-          if @order.update_attributes(order_params)
+          if @order.contents.update_cart(order_params)
             if params[:guest_checkout] == "false"
-              @order.associate_user!(Spree.user_class.find(params[:user_id]), @order.email.blank?)
+              requsted_user = Spree.user_class.find(params[:user_id])
+              @order.contents.associate_user(requsted_user, @order.email.blank?)
             end
             @order.next
-            @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
+            @order.refresh_shipment_rates
             flash[:success] = Spree.t('customer_details_updated')
             redirect_to edit_admin_order_url(@order)
           else
@@ -44,7 +45,7 @@ module Spree
           end
 
           def load_order
-            @order = Order.includes(:adjustments).friendly.find(params[:order_id])
+            @order = Order.includes(:adjustments).find_by_number!(params[:order_id])
           end
 
           def model_class

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -2,17 +2,17 @@ module Spree
   module Admin
     module Orders
       class CustomerDetailsController < Spree::Admin::BaseController
-        before_filter :load_order
+        before_action :load_order
 
         def show
           edit
-          render :action => :edit
+          render action: :edit
         end
 
         def edit
           country_id = Address.default.country.id
-          @order.build_bill_address(:country_id => country_id) if @order.bill_address.nil?
-          @order.build_ship_address(:country_id => country_id) if @order.ship_address.nil?
+          @order.build_bill_address(country_id: country_id) if @order.bill_address.nil?
+          @order.build_ship_address(country_id: country_id) if @order.ship_address.nil?
 
           @order.bill_address.country_id = country_id if @order.bill_address.country.nil?
           @order.ship_address.country_id = country_id if @order.ship_address.country.nil?
@@ -23,13 +23,12 @@ module Spree
             if params[:guest_checkout] == "false"
               @order.associate_user!(Spree.user_class.find(params[:user_id]), @order.email.blank?)
             end
-            while @order.next; end
-
-            @order.refresh_shipment_rates
+            @order.next
+            @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
             flash[:success] = Spree.t('customer_details_updated')
             redirect_to edit_admin_order_url(@order)
           else
-            render :action => :edit
+            render action: :edit
           end
 
         end
@@ -39,13 +38,13 @@ module Spree
             params.require(:order).permit(
               :email,
               :use_billing,
-              :bill_address_attributes => permitted_address_attributes,
-              :ship_address_attributes => permitted_address_attributes
+              bill_address_attributes: permitted_address_attributes,
+              ship_address_attributes: permitted_address_attributes
             )
           end
 
           def load_order
-            @order = Order.includes(:adjustments).find_by_number!(params[:order_id])
+            @order = Order.includes(:adjustments).friendly.find(params[:order_id])
           end
 
           def model_class

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+require "cancan"
+require "spree/testing_support/bar_ability"
+
+describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
+
+  context "with authorization" do
+    stub_authorization!
+
+    let(:order) do
+      mock_model(
+        Spree::Order,
+        total:           100,
+        number:          "R123456789",
+        billing_address: mock_model(Spree::Address)
+      )
+    end
+
+    before do
+      allow(Spree::Order).to receive_message_chain(:friendly, :find).and_return(order)
+    end
+
+    context "#update" do
+      it "does refresh the shipment rates with all shipping methods" do
+        allow(order).to receive_messages(update_attributes: true)
+        allow(order).to receive_messages(next: false)
+        expect(order).to receive(:refresh_shipment_rates)
+          .with(Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
+        attributes = {
+          order_id: order.number,
+          order: {
+            email: "",
+            use_billing: "",
+            bill_address_attributes: {},
+            ship_address_attributes: {}
+          }
+        }
+        spree_put :update, attributes
+      end
+    end
+  end
+end

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -42,6 +42,14 @@ module Spree
       end
     end
 
+    def associate_user(user, override_email = true)
+      order.associate_user!(user, override_email)
+      reload_totals
+      PromotionHandler::Cart.new(order).activate
+      reload_totals
+      true
+    end
+
     private
       def order_updater
         @updater ||= OrderUpdater.new(order)

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -209,4 +209,32 @@ describe Spree::OrderContents do
       }.to change { order.payment_state }
     end
   end
+
+  describe "#associate_user" do
+    let(:user) { Spree.user_class.new }
+    let(:order) { Spree::Order.new }
+
+    before do
+      allow_any_instance_of(Spree::OrderContents).to receive(:reload_totals)
+      allow_any_instance_of(Spree::Order).to receive(:associate_user!)
+      allow_any_instance_of(Spree::PromotionHandler::Cart).to receive(:activate)
+    end
+
+    subject { described_class.new(order).associate_user(user, true) }
+
+    it "associates the user" do
+      expect(order).to receive(:associate_user!).with(user, true)
+      subject
+    end
+
+    it "attempts to re-activate promotions" do
+      expect_any_instance_of(Spree::PromotionHandler::Cart).to receive(:activate)
+      subject
+    end
+
+    it "reloads totals" do
+      expect_any_instance_of(Spree::OrderContents).to receive(:reload_totals).twice
+      subject
+    end
+  end
 end


### PR DESCRIPTION
* Bring over updates and specs from master for that controller.
* Introduce OrderContents#associate user (soon to become beefier to pull it out of the order model).
* Use OrderContents from the customer_details controller.