### PR TITLE
move Order#merge! to OrderContents#merge

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -416,30 +416,6 @@ module Spree
      line_items.select(&:insufficient_stock?)
     end
 
-    def merge!(order, user = nil)
-      order.line_items.each do |line_item|
-        next unless line_item.currency == currency
-        current_line_item = self.line_items.find_by(variant: line_item.variant)
-        if current_line_item
-          current_line_item.quantity += line_item.quantity
-          current_line_item.save
-        else
-          line_item.order_id = self.id
-          line_item.save
-        end
-      end
-
-      self.associate_user!(user) if !self.user && !user.blank?
-
-      updater.update_item_count
-      updater.update_item_total
-      updater.persist_totals
-
-      # So that the destroy doesn't take out line items which may have been re-assigned
-      order.line_items.reload
-      order.destroy
-    end
-
     def empty!
       line_items.destroy_all
       updater.update_item_count

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -62,7 +62,7 @@ module Spree
             if session[:order_id].nil? && last_incomplete_order
               session[:order_id] = last_incomplete_order.id
             elsif current_order && last_incomplete_order && current_order != last_incomplete_order
-              current_order.merge!(last_incomplete_order, user)
+              current_order.contents.merge(last_incomplete_order, user: user)
             end
           end
         end

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -237,4 +237,63 @@ describe Spree::OrderContents do
       subject
     end
   end
+
+  describe "#merge" do
+    let(:variant) { create(:variant) }
+    let(:order_1) { Spree::Order.create! }
+    let(:order_2) { Spree::Order.create! }
+
+    it "destroys the other order" do
+      order_1.contents.merge(order_2)
+      lambda { order_2.reload }.should raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    context "user is provided" do
+      let(:user) { create(:user) }
+
+      it "assigns user to new order" do
+        order_1.contents.merge(order_2, user: user)
+        expect(order_1.user).to eq user
+      end
+    end
+
+    context "merging together two orders with line items for the same variant" do
+      before do
+        order_1.contents.add(variant, 1)
+        order_2.contents.add(variant, 1)
+      end
+
+      specify do
+        order_1.contents.merge(order_2)
+        order_1.line_items.count.should == 1
+
+        line_item = order_1.line_items.first
+        line_item.quantity.should == 2
+        line_item.variant_id.should == variant.id
+      end
+    end
+
+    context "merging together two orders with different line items" do
+      let(:variant_2) { create(:variant) }
+
+      before do
+        order_1.contents.add(variant, 1)
+        order_2.contents.add(variant_2, 1)
+      end
+
+      specify do
+        order_1.contents.merge(order_2)
+        line_items = order_1.line_items
+        line_items.count.should == 2
+
+        expect(order_1.item_count).to eq 2
+        expect(order_1.item_total).to eq line_items.map(&:amount).sum
+
+        # No guarantee on ordering of line items, so we do this:
+        line_items.pluck(:quantity).should =~ [1, 1]
+        line_items.pluck(:variant_id).should =~ [variant.id, variant_2.id]
+      end
+    end
+  end
+
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -500,63 +500,6 @@ describe Spree::Order do
     end
   end
 
-  # Regression tests for #2179
-  context "#merge!" do
-    let(:variant) { create(:variant) }
-    let(:order_1) { Spree::Order.create }
-    let(:order_2) { Spree::Order.create }
-
-    it "destroys the other order" do
-      order_1.merge!(order_2)
-      lambda { order_2.reload }.should raise_error(ActiveRecord::RecordNotFound)
-    end
-
-    context "user is provided" do
-      it "assigns user to new order" do
-        order_1.merge!(order_2, user)
-        expect(order_1.user).to eq user
-      end
-    end
-
-    context "merging together two orders with line items for the same variant" do
-      before do
-        order_1.contents.add(variant, 1)
-        order_2.contents.add(variant, 1)
-      end
-
-      specify do
-        order_1.merge!(order_2)
-        order_1.line_items.count.should == 1
-
-        line_item = order_1.line_items.first
-        line_item.quantity.should == 2
-        line_item.variant_id.should == variant.id
-      end
-    end
-
-    context "merging together two orders with different line items" do
-      let(:variant_2) { create(:variant) }
-
-      before do
-        order_1.contents.add(variant, 1)
-        order_2.contents.add(variant_2, 1)
-      end
-
-      specify do
-        order_1.merge!(order_2)
-        line_items = order_1.line_items
-        line_items.count.should == 2
-
-        expect(order_1.item_count).to eq 2
-        expect(order_1.item_total).to eq line_items.map(&:amount).sum
-
-        # No guarantee on ordering of line items, so we do this:
-        line_items.pluck(:quantity).should =~ [1, 1]
-        line_items.pluck(:variant_id).should =~ [variant.id, variant_2.id]
-      end
-    end
-  end
-
   # Regression test for #2191
   context "when an order has an adjustment that zeroes the total, but another adjustment for shipping that raises it above zero" do
     let!(:persisted_order) { create(:order) }


### PR DESCRIPTION
Part of moving all order modifications code to the OrderContents interface.
It appears that only frontend used this code.