### PR TITLE
Invert associate_user calls to use OrderContents

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -46,7 +46,7 @@ module Spree
         if @order.update_attributes(order_params)
           @order.update_line_items(line_items)
           if current_api_user.has_spree_role?('admin') && user_id.present?
-            @order.associate_user!(Spree.user_class.find(user_id))
+            @order.contents.associate_user(Spree.user_class.find(user_id))
           end
           return if after_update_attributes
           state_callback(:after) if @order.next

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -231,10 +231,11 @@ module Spree
 
     # Regression test for #3404
     it "can specify additional parameters for a line item" do
-      Order.should_receive(:create!).and_return(order = Spree::Order.new)
-      order.stub(:associate_user!)
-      order.stub_chain(:contents, :add).and_return(line_item = double('LineItem'))
-      line_item.should_receive(:update_attributes).with("special" => true)
+      order, line_item = Spree::Order.new, double('LineItem')
+      expect(Order).to receive(:create!) { order }
+      allow(order).to receive(:contents) { double(associate_user: true, add: line_item) }
+
+      expect(line_item).to receive(:update_attributes).with("special" => true)
 
       controller.stub(permitted_line_item_attributes: [:id, :variant_id, :quantity, :special])
       api_post :create, :order => {
@@ -271,10 +272,11 @@ module Spree
 
     # Regression test for #3404
     it "does not update line item needlessly" do
-      Order.should_receive(:create!).and_return(order = Spree::Order.new)
-      order.stub(:associate_user!)
-      order.stub_chain(:contents, :add).and_return(line_item = double('LineItem'))
-      line_item.should_not_receive(:update_attributes)
+      order, line_item = Spree::Order.new, double('LineItem')
+      expect(Order).to receive(:create!) { order }
+      allow(order).to receive(:contents) { double(associate_user: true, add: line_item) }
+      expect(line_item).not_to receive(:update_attributes)
+
       api_post :create, :order => {
         :line_items => {
           "0" => {

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -81,8 +81,7 @@ module Spree
         end
       end
 
-      # TODO: Call this class's `associate_user' method after it's merged in
-      order.associate_user!(user) if order.user.nil? && user
+      associate_user(user) if order.user.nil? && user
 
       order.updater.update_item_count
       order.update!

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -49,8 +49,8 @@ module Spree
 
         def associate_user
           @order ||= current_order
-          if try_spree_current_user && @order
-            @order.associate_user!(try_spree_current_user) if @order.user.blank? || @order.email.blank?
+          if try_spree_current_user && @order && (@order.user.blank? || @order.email.blank?)
+            @order.contents.associate_user(try_spree_current_user)
           end
 
           session[:guest_token] = nil

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -11,7 +11,7 @@ module Spree
             ensure_state_id_from_params params[:bill_address_attributes]
 
             order = Spree::Order.create!
-            order.associate_user!(user)
+            order.contents.associate_user(user)
 
             create_shipments_from_params(params.delete(:shipments_attributes), order)
             create_line_items_from_params(params.delete(:line_items_attributes),order)

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -19,7 +19,7 @@ module Spree
     end
 
     def charge_for_items
-      new_order.associate_user!(@original_order.user) if @original_order.user
+      new_order.contents.associate_user(@original_order.user) if @original_order.user
 
       add_exchange_variants_to_order
 

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -56,7 +56,7 @@ describe Spree::CheckoutController do
 
       it "should associate the order with a user" do
         order.user = nil
-        order.should_receive(:associate_user!).with(user)
+        order.contents.should_receive(:associate_user).with(user)
         spree_get :edit, {}, :order_id => 1
       end
     end


### PR DESCRIPTION
NOTE: depends on / has a commit from https://github.com/bonobos/spree/pull/193