### PR TITLE
Allow admins to sepcify stock locations when adding line items to orders

### DIFF
--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -6,7 +6,7 @@ module Spree
 
       def create
         variant = Spree::Variant.find(params[:line_item][:variant_id])
-        @line_item = @order.contents.add(variant, params[:line_item][:quantity] || 1)
+        @line_item = @order.contents.add(variant, params[:line_item][:quantity] || 1, stock_location_quantities: params[:line_item][:stock_location_quantities])
         if @line_item.errors.empty?
           respond_with(@line_item, status: 201, default_template: :show)
         else

--- a/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js.erb
@@ -29,19 +29,32 @@ addVariant = function() {
     $('#stock_details').hide();
 
     var variant_id = $('input.variant_autocomplete').val();
-    var quantity = $("input.quantity[data-variant-id='" + variant_id + "']").val();
+    var total_quantity = 0;
+    var stock_location_quantities = {};
 
-    adjustLineItems(order_number, variant_id, quantity);
+    if ($(".stock-levels.untracked-inventory").length > 0) {
+        total_quantity = $("input#variant_quantity").val();
+    }
+    else {
+        var quantities = $("input.quantity[data-variant-id='" + variant_id + "']");
+
+        quantities.each(function() {
+            total_quantity += Number($(this).val());
+            stock_location_quantities[$(this).attr('data-stock-location-id')] = $(this).val();
+        });
+    }
+
+    adjustLineItems(order_number, variant_id, total_quantity, stock_location_quantities);
     return 1
 }
 
-adjustLineItems = function(order_number, variant_id, quantity){
+adjustLineItems = function(order_number, variant_id, quantity, stock_location_quantities){
     var url = Spree.routes.orders_api + "/" + order_number + '/line_items';
 
     $.ajax({
         type: "POST",
         url: Spree.url(url),
-        data: { line_item: {variant_id: variant_id, quantity: quantity }}
+        data: { line_item: {variant_id: variant_id, quantity: quantity,  stock_location_quantities: stock_location_quantities}}
     }).done(function( msg ) {
         window.Spree.advanceOrder();
         window.location.reload();

--- a/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
+++ b/backend/app/views/spree/admin/variants/_autocomplete_line_items_stock.js.erb
@@ -1,49 +1,69 @@
 <script type='text/template' id='variant_line_items_autocomplete_stock_template'>
   <fieldset>
     <legend align="center"><%= Spree.t(:select_stock) %></legend>
-    <table class="stock-levels" data-hook="stock-levels">
-      <colgroup>
-        <col style="width: 30%;" />
-        <col style="width: 40%;" />
-        <col style="width: 30%;" />
-      </colgroup>
-      <thead>
-        <th><%= Spree.t(:name) %></th>
-        <th><%= Spree.t(:count_on_hand) %></th>
-        <th><%= Spree.t(:quantity) %></th>
-        <th class="actions"></th>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{{variant.name}}</td>
-          {{#unless variant.track_inventory}}
-            <td>
-            It doesnt track inventory
-            </td>
-            <td>
-              <input class="quantity" id="variant_quantity" data-variant-id="{{variant.id}}" type="number" min="1" value="1">
-            </td>
-            <td class="actions">
-              <button class="add_variant no-text fa fa-plus icon_link with-tip" data-variant-id="{{this.variant_id}}" title="<%= Spree.t(:add) %>" data-action="add"></button>
-            </td>
-          {{else}}
-            {{#if variant.total_on_hand}}
+    {{#if variant.track_inventory}}
+      <table class="stock-levels" data-hook="stock-levels">
+        <colgroup>
+          <col style="width: 30%;" />
+          <col style="width: 40%;" />
+          <col style="width: 30%;" />
+        </colgroup>
+        <thead>
+          <th><%= Spree.t(:name) %></th>
+          <th><%= Spree.t(:location) %></th>
+          <th><%= Spree.t(:count_on_hand) %></th>
+          <th><%= Spree.t(:quantity) %></th>
+        </thead>
+        <tbody>
+          {{#each variant.stock_items}}
+            <tr>
+              <td>{{#unless @index}}{{../../variant.name}}{{/unless}}</td>
               <td>
-                {{variant.total_on_hand}}
+                {{stock_location_name}}
               </td>
               <td>
-                <input class="quantity" id="variant_quantity" data-variant-id="{{variant.id}}" type="number" min="1" value="1">
+                {{count_on_hand}}
               </td>
-              <td class="actions">
-                <button class="add_variant no-text fa fa-plus icon_link with-tip" data-variant-id="{{variant.id}}" title="<%= Spree.t(:add) %>" data-action="add"></button>
+              <td>
+                <input class="quantity variant_quantity" id="quantity_{{@index}}" data-variant-id="{{../variant.id}}" data-stock-location-id="{{stock_location_id}}" type="number" min="0" value="0">
               </td>
-            {{else}}
-              <td><%= Spree.t(:out_of_stock) %></td>
-              <td>0</td>
-            {{/if}}
-          {{/unless}}
-        </tr>
-      </tbody>
-    </table>
+              </tr>
+          {{/each}}
+        </tbody>
+      </table>
+    {{else}}
+      <table class="stock-levels untracked-inventory" data-hook="stock-levels">
+        <colgroup>
+          <col style="width: 30%;" />
+          <col style="width: 40%;" />
+          <col style="width: 30%;" />
+        </colgroup>
+        <thead>
+          <th><%= Spree.t(:name) %></th>
+          <th><%= Spree.t(:count_on_hand) %></th>
+          <th><%= Spree.t(:quantity) %></th>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              {{variant.name}}
+            </td>
+            <td>
+              No inventory necessary
+            </td>
+            <td>
+              <input class="quantity" id="variant_quantity" data-variant-id="{{variant.id}}" type="number" min="0" value="0">
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    {{/if}}
+
+
+    <fieldset class="no-border-bottom">
+      <legend align="center" class="stock-location">
+        <button class="add_variant no-text fa fa-plus icon_link"  title="<%= Spree.t(:add) %>" data-action="add"><%= Spree.t(:add) %></button>
+      </legend>
+    </fieldset>
   </fieldset>
 </script>

--- a/backend/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/base_controller_spec.rb
@@ -17,7 +17,7 @@ describe Spree::Admin::BaseController do
     end
 
     it "checks error" do
-      controller.stub root_path: "/rooot"
+      allow(controller).to receive_message_chain(:spree, :root_path).and_return('/rooot')
       get :index
       expect(response).to redirect_to "/rooot"
     end

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -23,8 +23,11 @@ describe "New Order" do
     expect(current_path).to eql(spree.edit_admin_order_customer_path(Spree::Order.last))
   end
 
-  it "completes new order succesfully withous using the cart", js: true do
+  it "completes new order succesfully without using the cart", js: true do
     select2_search product.name, :from => Spree.t(:name_or_sku)
+
+    fill_in_quantity("table.stock-levels", "quantity_0", 2)
+
     click_icon :plus
     wait_for_ajax
     click_on "Customer Details"
@@ -61,10 +64,10 @@ describe "New Order" do
     it "inventory items show up just fine and are also registered as shipments" do
       select2_search product.name, :from => Spree.t(:name_or_sku)
 
-      within("table.stock-levels") do
-        fill_in "variant_quantity", :with => 2
-        click_icon :plus
-      end
+      fill_in_quantity('table.stock-levels', 'quantity_0', 2)
+
+      click_icon :plus
+      wait_for_ajax
 
       within(".line-items") do
         page.should have_content(product.name)
@@ -96,7 +99,12 @@ describe "New Order" do
 
     it "can still see line items" do
       select2_search product.name, :from => Spree.t(:name_or_sku)
+
+      fill_in_quantity('table.stock-levels', 'quantity_0', 1)
+
       click_icon :plus
+      wait_for_ajax
+
       within(".line-items") do
         within(".line-item-name") do
           page.should have_content(product.name)

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -44,9 +44,11 @@ describe "Order Details", js: true do
       it "can add an item to a shipment" do
         select2_search "spree t-shirt", :from => Spree.t(:name_or_sku)
         within("table.stock-levels") do
-          fill_in "variant_quantity", :with => 2
-          click_icon :plus
+          fill_in "quantity_0", :with => 2
         end
+
+        click_icon :plus
+        wait_for_ajax
 
         within("#order_total") do
           page.should have_content("$80.00")
@@ -132,8 +134,10 @@ describe "Order Details", js: true do
           select2_search tote.name, :from => Spree.t(:name_or_sku)
           within("table.stock-levels") do
             fill_in "variant_quantity", :with => 1
-            click_icon :plus
           end
+
+          click_icon :plus
+          wait_for_ajax
 
           within(".line-items") do
             page.should have_content(tote.name)
@@ -151,7 +155,7 @@ describe "Order Details", js: true do
           select2_search product.name, :from => Spree.t(:name_or_sku)
 
           within("table.stock-levels") do
-            page.should have_content(Spree.t(:out_of_stock))
+            page.should have_content(0)
           end
         end
       end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -52,6 +52,9 @@ module Spree
     has_many :variants, through: :line_items
     has_many :refunds, through: :payments
 
+    has_many :order_stock_locations, class_name: "Spree::OrderStockLocation"
+    has_many :stock_locations, through: :order_stock_locations
+
     has_and_belongs_to_many :promotions, join_table: 'spree_orders_promotions'
 
     has_many :shipments, dependent: :destroy, inverse_of: :order do

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -6,8 +6,8 @@ module Spree
       @order = order
     end
 
-    def add(variant, quantity = 1, currency = nil, shipment = nil)
-      line_item = add_to_line_item(variant, quantity, currency, shipment)
+    def add(variant, quantity = 1, currency = nil, shipment = nil, stock_location_quantities: nil)
+      line_item = add_to_line_item(variant, quantity, currency, shipment, stock_location_quantities: stock_location_quantities)
       reload_totals
       shipment.present? ? shipment.update_amounts : order.ensure_updated_shipments
       PromotionHandler::Cart.new(order, line_item).activate
@@ -53,7 +53,7 @@ module Spree
         order.reload
       end
 
-      def add_to_line_item(variant, quantity, currency=nil, shipment=nil)
+      def add_to_line_item(variant, quantity, currency=nil, shipment=nil, stock_location_quantities: nil)
         line_item = grab_line_item_by_variant(variant)
 
         if line_item
@@ -62,6 +62,7 @@ module Spree
           line_item.currency = currency unless currency.nil?
         else
           line_item = order.line_items.new(quantity: quantity, variant: variant)
+          create_order_stock_locations(line_item, stock_location_quantities)
           line_item.target_shipment = shipment
           if currency
             line_item.currency = currency
@@ -97,6 +98,14 @@ module Spree
         end
 
         line_item
+      end
+
+      def create_order_stock_locations(line_item, stock_location_quantities)
+        return unless stock_location_quantities.present?
+        order = line_item.order
+        stock_location_quantities.each do |stock_location_id, quantity|
+          order.order_stock_locations.create!(stock_location_id: stock_location_id, quantity: quantity, variant_id: line_item.variant_id) unless quantity.to_i.zero?
+        end
       end
   end
 end

--- a/core/app/models/spree/order_stock_location.rb
+++ b/core/app/models/spree/order_stock_location.rb
@@ -1,0 +1,15 @@
+module Spree
+  class OrderStockLocation < ActiveRecord::Base
+    belongs_to :variant, class_name: "Spree::Variant"
+    belongs_to :stock_location, class_name: "Spree::StockLocation"
+    belongs_to :order, class_name: "Spree::Order"
+
+    def self.fulfill_for_order_with_stock_location(order, stock_location)
+      self.where(order_id: order.id, stock_location_id: stock_location.id).each(&:fulfill_shipment!)
+    end
+
+    def fulfill_shipment!
+      self.update_attributes!(shipment_fulfilled: true)
+    end
+  end
+end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -390,7 +390,12 @@ module Spree
         inventory_units.each &:ship!
         send_shipped_email
         touch :shipped_at
+        fulfill_order_with_stock_location
         update_order_shipment_state
+      end
+
+      def fulfill_order_with_stock_location
+        Spree::OrderStockLocation.fulfill_for_order_with_stock_location(order, stock_location)
       end
 
       def update_order_shipment_state

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -6,6 +6,7 @@ module Spree
       def initialize(order, inventory_units = nil)
         @order = order
         @inventory_units = inventory_units || InventoryUnitBuilder.new(order).units
+        @preallocated_inventory_units = []
       end
 
       def shipments
@@ -15,9 +16,33 @@ module Spree
       end
 
       def packages
-        packages = build_packages
+        packages = build_location_configured_packages
+        packages = build_packages(packages)
         packages = prioritize_packages(packages)
         packages = estimate_packages(packages)
+      end
+
+      # Build packages for the inventory units that have preferred stock locations first
+      #
+      # Certain variants have been selected to be fulfilled from a particular stock
+      # location during the process of the order being created. The rest of the
+      # service objects the coordinator uses do a lot of automated logic to
+      # determine which stock location is best for the inventory unit to be
+      # fulfilled from, but for these special snowflakes we KNOW which stock
+      # location they should be fulfilled from. So rather than sending these units
+      # through the rest of the packing / prioritization, lets just put them
+      # in packages we know they should be in and deal with other automatically-
+      # handled inventory units otherwise.
+      def build_location_configured_packages(packages = Array.new)
+        order.order_stock_locations.where(shipment_fulfilled: false).group_by(&:stock_location).each do |stock_location, stock_location_configurations|
+          units = stock_location_configurations.flat_map do |stock_location_configuration|
+            unallocated_inventory_units.select { |iu| iu.variant == stock_location_configuration.variant }.take(stock_location_configuration.quantity)
+          end
+          packer = build_packer(stock_location, units)
+          packages += packer.packages
+          @preallocated_inventory_units += units
+        end
+        packages
       end
 
       # Build packages as per stock location
@@ -27,19 +52,23 @@ module Spree
       # to build a package because it would be empty. Plus we avoid errors down
       # the stack because it would assume the stock location has stock items
       # for the given order
-      # 
+      #
       # Returns an array of Package instances
       def build_packages(packages = Array.new)
         StockLocation.active.each do |stock_location|
-          next unless stock_location.stock_items.where(:variant_id => inventory_units.map(&:variant_id)).exists?
-
-          packer = build_packer(stock_location, inventory_units)
+          next unless stock_location.stock_items.where(variant_id: unallocated_inventory_units.map(&:variant_id).uniq).exists?
+          packer = build_packer(stock_location, unallocated_inventory_units)
           packages += packer.packages
         end
         packages
       end
 
       private
+
+      def unallocated_inventory_units
+        inventory_units - @preallocated_inventory_units
+      end
+
       def prioritize_packages(packages)
         prioritizer = Prioritizer.new(inventory_units, packages)
         prioritizer.prioritized_packages

--- a/core/db/migrate/20150127161843_create_order_stock_locations.rb
+++ b/core/db/migrate/20150127161843_create_order_stock_locations.rb
@@ -1,0 +1,12 @@
+class CreateOrderStockLocations < ActiveRecord::Migration
+  def change
+    create_table :spree_order_stock_locations do |t|
+      t.integer :order_id
+      t.integer :variant_id
+      t.integer :quantity
+      t.integer :stock_location_id
+      t.boolean :shipment_fulfilled, null: false, default: false
+      t.timestamps
+    end
+  end
+end

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -28,6 +28,12 @@ module CapybaraExt
     end
   end
 
+  def fill_in_quantity(table_column, selector, quantity)
+    within(table_column) do
+      fill_in selector, :with => quantity
+    end
+  end
+
   def set_select2_field(field, value)
     page.execute_script %Q{$('#{field}').select2('val', '#{value}')}
   end

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe Spree::OrderContents do
   let(:order) { Spree::Order.create }
   let(:variant) { create(:variant) }
+  let!(:stock_location) { variant.stock_locations.first }
+  let(:stock_location_2) { create(:stock_location) }
 
   subject { described_class.new(order) }
 
@@ -52,6 +54,14 @@ describe Spree::OrderContents do
 
       order.item_total.to_f.should == 19.99
       order.total.to_f.should == 19.99
+    end
+
+    it "should create stock location associations if provided" do
+      line_item = subject.add(variant, 3, stock_location_quantities: {stock_location.id => 1, stock_location_2.id => 2})
+      order_stock_locations = line_item.order.order_stock_locations
+      order_stock_locations.count.should == 2
+      order_stock_locations.map(&:quantity).should == [1, 2]
+      order_stock_locations.map(&:stock_location_id).should == [stock_location.id, stock_location_2.id]
     end
 
     context "running promotions" do

--- a/core/spec/models/spree/order_stock_location_spec.rb
+++ b/core/spec/models/spree/order_stock_location_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+module Spree
+  describe OrderStockLocation do
+    describe ".fulfill_for_order_with_stock_location" do
+      subject { OrderStockLocation.fulfill_for_order_with_stock_location(order, stock_location) }
+
+      let(:order) { create(:order) }
+      let(:stock_location) { create(:stock_location) }
+      let!(:order_stock_location) { Spree::OrderStockLocation.create!(order: order, stock_location: stock_location) }
+
+      it "fulfills the shipment for the order and stock location combination" do
+        subject
+        expect(order_stock_location.reload.shipment_fulfilled).to eq(true)
+      end
+    end 
+  end
+end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -8,10 +8,12 @@ describe Spree::Shipment do
                                          currency: 'USD',
                                          touch: true }
   let(:shipping_method) { create(:shipping_method, name: "UPS") }
+  let(:stock_location) { create(:stock_location) }
   let(:shipment) do
     shipment = Spree::Shipment.new
     shipment.stub(shipping_method: shipping_method)
     shipment.stub(order: order)
+    shipment.stub(stock_location: stock_location)
     shipment.state = 'pending'
     shipment.cost = 1
     shipment.save
@@ -414,6 +416,13 @@ describe Spree::Shipment do
 
           shipment.ship!
           shipment_id.should == shipment.id
+        end
+
+        it "should call fulfill_order_with_stock_location" do
+          shipment.stub(:update_order_shipment_state)
+          shipment.stub(:send_shipped_email)
+          shipment.should_receive(:fulfill_order_with_stock_location)
+          shipment.ship!
         end
 
         it "finalizes adjustments" do

--- a/core/spec/models/spree/stock/coordinator_spec.rb
+++ b/core/spec/models/spree/stock/coordinator_spec.rb
@@ -3,12 +3,13 @@ require 'spec_helper'
 module Spree
   module Stock
     describe Coordinator do
-      let!(:order) { create(:order_with_line_items) }
+      let!(:order) { create(:order_with_line_items, line_items_count: 2) }
 
       subject { Coordinator.new(order) }
 
       context "packages" do
         it "builds, prioritizes and estimates" do
+          subject.should_receive(:build_location_configured_packages).ordered
           subject.should_receive(:build_packages).ordered
           subject.should_receive(:prioritize_packages).ordered
           subject.should_receive(:estimate_packages).ordered
@@ -34,15 +35,41 @@ module Spree
       end
 
       context "build packages" do
-        it "builds a package for every stock location" do
+        it "builds a package for all active stock locations" do
           subject.packages.count == StockLocation.count
         end
 
-        context "missing stock items in stock location" do
+        context "missing stock items in active stock location" do
           let!(:another_location) { create(:stock_location, propagate_all_variants: false) }
 
-          it "builds packages only for valid stock locations" do
+          it "builds packages only for valid active stock locations" do
             subject.build_packages.count.should == (StockLocation.count - 1)
+          end
+        end
+      end
+
+      context "build location configured packages" do
+        context "there are configured stock locations" do
+          let(:stock_location) { order.variants.first.stock_locations.first }
+          let!(:stock_location_2) { create(:stock_location) }
+
+          before do
+            line_item_1 = order.line_items.first
+            line_item_2 = order.line_items.last
+            order.order_stock_locations.create(stock_location_id: stock_location.id, quantity: line_item_1.quantity, variant_id: line_item_1.variant_id)
+            order.order_stock_locations.create(stock_location_id: stock_location_2.id, quantity: line_item_2.quantity, variant_id: line_item_2.variant_id)
+          end
+
+          it "builds a package for each associated stock location" do
+            packages = subject.build_location_configured_packages
+            expect(packages.count).to eq(2)
+            expect(packages.map(&:stock_location)).to eq([stock_location, stock_location_2])
+          end
+        end
+        context "there are no configured stock locations" do
+          it "doesn't build any packages" do
+            packages = subject.build_location_configured_packages
+            expect(packages.count).to eq(0)
           end
         end
       end


### PR DESCRIPTION
* Admin panel shows a table of all stock locations which you can pull stock from
* Add association between order and variant to many stock locations
* Create associated stock locations when adding a line item through admin
* StockCoordinator will first build packages with configured stock locations, and if not configured it will build packages from active stock locations like before.