### PR TITLE
Fix factory_girl ignore/transient deprecation warning

### DIFF
--- a/core/lib/spree/testing_support/factories/customer_return_factory.rb
+++ b/core/lib/spree/testing_support/factories/customer_return_factory.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
   factory :customer_return, class: Spree::CustomerReturn do
     association(:stock_location, factory: :stock_location)
 
-    ignore do
+    transient do
       line_items_count 1
       return_items_count { line_items_count }
     end

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     completed_at nil
     email { user.email }
 
-    ignore do
+    transient do
       line_items_price BigDecimal.new(10)
     end
 
@@ -20,7 +20,7 @@ FactoryGirl.define do
       bill_address
       ship_address
 
-      ignore do
+      transient do
         line_items_count 5
         shipment_cost 100
       end

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     name 'Promo'
 
     trait :with_line_item_adjustment do
-      ignore do
+      transient do
         adjustment_rate 10
       end
 
@@ -18,7 +18,7 @@ FactoryGirl.define do
     factory :promotion_with_item_adjustment, traits: [:with_line_item_adjustment]
 
     trait :with_order_adjustment do
-      ignore do
+      transient do
         weighted_order_adjustment_amount 10
       end
 
@@ -32,7 +32,7 @@ FactoryGirl.define do
     end
 
     trait :with_item_total_rule do
-      ignore do
+      transient do
         item_total_threshold_amount 10
       end
 

--- a/core/lib/spree/testing_support/factories/reimbursement_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :reimbursement, class: Spree::Reimbursement do
-    ignore do
+    transient do
       return_items_count 1
     end
 

--- a/core/lib/spree/testing_support/factories/stock_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_factory.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   # must use build()
   factory :stock_packer, class: Spree::Stock::Packer do
-    ignore do
+    transient do
       stock_location { build(:stock_location) }
       contents []
     end
@@ -10,7 +10,7 @@ FactoryGirl.define do
   end
 
   factory :stock_package, class: Spree::Stock::Package do
-    ignore do
+    transient do
       stock_location { build(:stock_location) }
       contents       { [] }
       variants_contents { {} }
@@ -25,7 +25,7 @@ FactoryGirl.define do
     end
 
     factory :stock_package_fulfilled do
-      ignore { variants_contents { { build(:variant) => 2 } } }
+      transient { variants_contents { { build(:variant) => 2 } } }
     end
   end
 end


### PR DESCRIPTION
Fixes deprecation warnings like this:

> DEPRECATION WARNING: `#ignore` is deprecated and will be removed in 5.0. Please use `#transient` instead. (called from block (2 levels) in <top (required)> at /home/ubuntu/spree/core/lib/spree/testing_support/factories/customer_return_factory.rb:6)