### PR TITLE
Add OrderContents#apply_coupon_code

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -127,7 +127,7 @@ module Spree
 
         def after_update_attributes
           if object_params && object_params[:coupon_code].present?
-            handler = PromotionHandler::Coupon.new(@order).apply
+            handler = @order.contents.apply_coupon_code(object_params[:coupon_code])
 
             if handler.error.present?
               @coupon_message = handler.error

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -89,8 +89,7 @@ module Spree
 
       def apply_coupon_code
         authorize! :update, @order, order_token
-        @order.coupon_code = params[:coupon_code]
-        @handler = PromotionHandler::Coupon.new(@order).apply
+        @handler = @order.contents.apply_coupon_code(params[:coupon_code])
         status = @handler.successful? ? 200 : 422
         render "spree/api/promotions/handler", :status => status
       end

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -639,6 +639,46 @@ module Spree
         end
       end
     end
+
+    describe '#apply_coupon_code' do
+      let(:promo) { create(:promotion_with_item_adjustment, code: 'abc') }
+
+      before do
+        Order.any_instance.stub :user => current_api_user
+      end
+
+      context 'when successful' do
+        let(:order) { create(:order_with_line_items) }
+
+        it 'applies the coupon' do
+          api_put :apply_coupon_code, id: order.to_param, coupon_code: promo.code
+
+          expect(response.status).to eq 200
+          expect(order.reload.promotions).to eq [promo]
+          expect(json_response).to eq({
+            "success" => Spree.t(:coupon_code_applied),
+            "error" => nil,
+            "successful" => true,
+          })
+        end
+      end
+
+      context 'when unsuccessful' do
+        let(:order) { create(:order) } # no line items to apply the code to
+
+        it 'returns an error' do
+          api_put :apply_coupon_code, id: order.to_param, coupon_code: promo.code
+
+          expect(response.status).to eq 422
+          expect(order.reload.promotions).to eq []
+          expect(json_response).to eq({
+            "success" => nil,
+            "error" => Spree.t(:coupon_code_unknown_error),
+            "successful" => false,
+          })
+        end
+      end
+    end
   end
 end
 

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -108,6 +108,11 @@ module Spree
       reload_totals
     end
 
+    def apply_coupon_code(coupon_code)
+      order.coupon_code = coupon_code
+      PromotionHandler::Coupon.new(order).apply
+    end
+
     private
       def order_updater
         @updater ||= OrderUpdater.new(order)

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -364,4 +364,15 @@ describe Spree::OrderContents do
     end
   end
 
+  describe "#apply_coupon_code" do
+    let(:order) { create(:order_with_line_items) }
+    let(:promo) { create(:promotion_with_item_adjustment, code: 'abc') }
+
+    it "applies the promo and returns the handler" do
+      result = order.contents.apply_coupon_code(promo.code)
+      expect(order.reload.promotions).to eq [promo]
+      expect(result).to be_a Spree::PromotionHandler::Coupon
+    end
+  end
+
 end

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -17,9 +17,7 @@ module Spree
       # which needs it)
       def apply_coupon_code
         if params[:order] && params[:order][:coupon_code]
-          @order.coupon_code = params[:order][:coupon_code]
-
-          handler = PromotionHandler::Coupon.new(@order).apply
+          handler = @order.contents.apply_coupon_code(params[:order][:coupon_code])
 
           if handler.error.present?
             flash.now[:error] = handler.error


### PR DESCRIPTION
And use it in the various controllers.

There were no controller specs around this stuff.  I added some specs for OrderContents and for Api::OrdersController.  In the interest of time I did not add any for Api::CheckoutsController (it's a mess) or the frontend StoreController (which we don't use).