### PR TITLE
Add functionality to complete orders with non-physical stock

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -34,6 +34,10 @@
             <%= f.label :active, Spree.t(:restock_inventory) %>
             <%= f.check_box :restock_inventory %>
           </li>
+          <li>
+            <%= f.label :active, Spree.t(:fulfillable_stock) %>
+            <%= f.check_box :fulfillable %>
+          </li>
         </ul>
       <% end %>
     </div>

--- a/core/db/migrate/20150203151219_add_fulfillable_to_stock_location.rb
+++ b/core/db/migrate/20150203151219_add_fulfillable_to_stock_location.rb
@@ -1,0 +1,5 @@
+class AddFulfillableToStockLocation < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_locations, :fulfillable, :boolean, default: true, null: false
+  end
+end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -571,4 +571,23 @@ describe Spree::Shipment do
       expect(state_change.next_state).to eq('ready')
     end
   end
+
+  context "don't require shipment" do
+    let(:stock_location) { create(:stock_location, fulfillable: false)}
+    let(:unshippable_shipment) { create(:shipment, stock_location: stock_location)}
+    before { order.stub paid?: true }
+
+    it 'proceeds automatically to shipped state' do
+      unshippable_shipment.ready!
+      expect(unshippable_shipment.state).to eq('shipped')
+    end
+
+    it 'does not send a confirmation email' do
+      expect(unshippable_shipment).to_not receive(:send_shipment_email)
+      unshippable_shipment.ready!
+      unshippable_shipment.inventory_units.each do |unit|
+        expect(unit.state).to eq('shipped')
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Add fulfillable flag to stock locations to indicate if stock location
  actually holds stock.
* Shipment will auto progress to 'shipped' state if shipment does not
  require shipment.
* Shipments that are shipped without requiring shipment will not send
  confirmation email.