### PR TITLE
Show payments on completed orders. 

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -60,7 +60,7 @@ module Spree
     end
 
     def sources_by_order(order)
-      source_ids = order.payments.where(source_type: payment_source_class.to_s, payment_method_id: self.id).pluck(:source_id).uniq
+      source_ids = order.payments.where(payment_method_id: self.id).pluck(:source_id).uniq
       payment_source_class.where(id: source_ids).with_payment_profile
     end
 


### PR DESCRIPTION
The way it is currently does not support payments where the source type does not match the payment_source_class in the gateway. In our case, the payment source_type is "Spree::CreditCard" and the payment_source_class is "Spree::EncryptedCreditCard".

If you look at line 64, the payment_source_class is used again to filter the results down, so removing this will not affect anything, except allowing for inheritence.

