### PR TITLE
Fix checkout bug

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -113,10 +113,6 @@ module Spree
           send(method_name) if respond_to?(method_name, true)
         end
 
-        def before_payment
-          @order.payments.destroy_all if request.put?
-        end
-
         def next!(options={})
           if @order.valid? && @order.next
             render 'spree/api/orders/show', status: options[:status] || 200

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -468,11 +468,12 @@ module Spree
     # to delivery again so that proper updated shipments are created.
     # e.g. customer goes back from payment step and changes order items
     def ensure_updated_shipments
-      if shipments.any? && !self.completed?
+      unless completed?
         self.shipments.destroy_all
         self.update_column(:shipment_total, 0)
-        restart_checkout_flow
       end
+
+      restart_checkout_flow if payment? || confirm?
     end
 
     def restart_checkout_flow


### PR DESCRIPTION
* Remove before_payment hook in checkouts controller -- its causing people to get stuck in payment state, and is not necessary. This has also been removed from 2-2-stable quite awhile ago.
* Remove the need for shipments when ensuring updated shipments and restarting the checkout flow. If we don't have any shipments to begin with, it doesnt hurt to destroy them and reset the shipment_total to 0. This was not allowing people in the payment state to restart their checkout flow.

The combination of these two changes will allow people who were formerly unable to enter a credit card and check out to be able to do so.