### PR TITLE
Make update_item_count get called inside updater#update

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -85,8 +85,7 @@ module Spree
 
       associate_user(user) if order.user.nil? && user
 
-      order.updater.update_item_count
-      order.update!
+      reload_totals
 
       # So that the destroy doesn't take out line items which may have been re-assigned
       other_order.line_items.reload
@@ -136,7 +135,6 @@ module Spree
       end
 
       def reload_totals
-        order_updater.update_item_count
         order_updater.update
         order.reload
       end

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -19,6 +19,7 @@ module Spree
       Rails.logger.info "update_caller=#{caller_info.inspect}"
 
       benchmark('update') do
+        update_item_count
         update_totals
         if order.completed?
           update_payment_state


### PR DESCRIPTION
This only adds a single SQL "sum" query and seems safer to always do it and gets us closer to always just calling "updater.update".