### PR TITLE
WIP initial attempt at what new order updater (and general behaviors cla...

### DIFF
--- a/core/behaviors/base.rb
+++ b/core/behaviors/base.rb
@@ -1,0 +1,43 @@
+module Spree
+  module Behaviors
+    class Base
+      class BehaviorFailureError < StandardError; end
+      attr_reader :errors, :object
+      class_attribute :pre_run_list
+      class_attribute :post_run_list
+      self.pre_run_list = []
+      self.post_run_list = []
+
+      def initialize(object)
+        @object = object
+        @errors = {}
+      end
+
+      def execute!
+        execute || raise(BehaviorFailureError.new(errors.inspect))
+      end
+
+      def execute
+        execute_run_list(pre_run_list)
+        run
+        execute_run_list(post_run_list)
+        errors.blank?
+      end
+
+      protected
+
+        def run
+          raise NotImplementedError
+        end
+
+      private
+
+        def execute_run_list(run_list)
+          run_list.each do |run_list_item|
+            run_list_item.new(object).execute
+            errors.deep_merge!(run_list_item.errors)
+          end
+        end
+    end
+  end
+end

--- a/core/behaviors/order/advance.rb
+++ b/core/behaviors/order/advance.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Behaviors
+    module Order
+      class Advance < Base
+        def run
+          while object.next; end
+        end
+      end
+    end
+  end
+end

--- a/core/behaviors/order/advance_shipments.rb
+++ b/core/behaviors/order/advance_shipments.rb
@@ -1,0 +1,13 @@
+module Spree
+  module Behaviors
+    module Order
+      class AdvanceShipments < Base
+        self.post_run_list = [DenormalizeTotals]
+        def run
+          return unless object.completed?
+          object.shipments.select(&:persisted?).each { |shipment| shipment.update!(object) }
+        end
+      end
+    end
+  end
+end

--- a/core/behaviors/order/calculate_adjustments.rb
+++ b/core/behaviors/order/calculate_adjustments.rb
@@ -1,0 +1,14 @@
+module Spree
+  module Behaviors
+    module Order
+      class CalculateAdjustments < Base
+
+        self.post_run_list = [DenormalizeTotals]
+
+        def run
+          object.all_adjustments.includes(:adjustable).map(&:adjustable).uniq.each { |adjustable| Spree::ItemAdjustments.new(adjustable).update }
+        end
+      end
+    end
+  end
+end

--- a/core/behaviors/order/calculate_promotions.rb
+++ b/core/behaviors/order/calculate_promotions.rb
@@ -1,0 +1,13 @@
+module Spree
+  module Behaviors
+    module Order
+      class CalculatePromotions < Base
+        self.post_run_list = [DenormalizeTotals]
+
+        def run
+          object.line_items.each { |li| PromotionHandler::Cart.new(object, li).activate }
+        end
+      end
+    end
+  end
+end

--- a/core/behaviors/order/denormalize_totals.rb
+++ b/core/behaviors/order/denormalize_totals.rb
@@ -1,0 +1,94 @@
+module Spree
+  module Behaviors
+    module Order
+      class DenormalizeTotals < Base
+        def run
+          # COUNTS
+          order.item_count = line_items.sum(:quantity)
+
+          # AMOUNTS
+          order.payment_total = payments.completed.sum(:amount)
+          order.item_total = line_items.sum(:amount)
+          order.shipment_total = shipments.sum(:cost)
+          order.adjustment_total = line_items.sum(:adjustment_total) +
+            shipments.sum(:adjustment_total) +
+            adjustments.eligible.sum(:amount)
+
+          order.included_tax_total = line_items.sum(:included_tax_total) +
+            shipments.sum(:included_tax_total)
+          order.additional_tax_total = line_items.sum(:additional_tax_total) +
+            shipments.sum(:additional_tax_total)
+
+          order.promo_total = line_items.sum(:promo_total) +
+            shipments.sum(:promo_total) +
+            adjustments.promotion.eligible.sum(:amount)
+
+          order.total = order.item_total + order.shipment_total + order.adjustment_total
+
+          # PAYMENT STATE
+          unless order.completed?
+            # line_item are empty when user empties cart
+            if line_items.empty? || round_money(order.payment_total) < round_money(order.total)
+              if payments.present?
+                # The gateway refunds the payment if possible when an order is canceled, so all canceled orders
+                # should have voided payments
+                if order.state == 'canceled'
+                  order.payment_state = 'void'
+                elsif payments.last.state == 'failed'
+                  order.payment_state = 'failed'
+                elsif payments.last.state == 'checkout'
+                  order.payment_state = 'pending'
+                elsif payments.last.state == 'completed'
+                  if line_items.empty?
+                    order.payment_state = 'credit_owed'
+                  else
+                    order.payment_state = 'balance_due'
+                  end
+                elsif payments.last.state == 'pending'
+                  order.payment_state = 'balance_due'
+                else
+                  order.payment_state = 'credit_owed'
+                end
+              else
+                order.payment_state = 'balance_due'
+              end
+            elsif round_money(order.payment_total) > round_money(order.total)
+              order.payment_state = 'credit_owed'
+            else
+              order.payment_state = 'paid'
+            end
+
+            order.state_changed('payment')
+          end
+
+          # SHIPMENT STATE
+          unless order.completed?
+            if order.backordered?
+              order.shipment_state = 'backorder'
+            else
+              # get all the shipment states for this order
+              shipment_states = shipments.states
+              if shipment_states.size > 1
+                # multiple shiment states means it's most likely partially shipped
+                order.shipment_state = 'partial'
+              else
+                # will return nil if no shipments are found
+                order.shipment_state = shipment_states.first
+              end
+            end
+            order.state_changed('shipment')
+          end
+        end
+
+        private
+
+        def order; object; end
+        def line_items; order.line_items; end
+        def shipments; order.shipments; end
+        def adjustments; order.adjustments; end
+        def payments; order.payments; end
+
+      end
+    end
+  end
+end

--- a/core/behaviors/order/recalculate.rb
+++ b/core/behaviors/order/recalculate.rb
@@ -1,0 +1,20 @@
+module Spree
+  module Behaviors
+    module Order
+      class Recalculate < Base
+        self.pre_run_list = [
+          DenormalizeTotals,
+          CalculateAdjustments,
+          CalculatePromotions,
+          # CalculateTaxes, # This doesn't happen in order updater currently, but this seems like the right place to me
+          Advance,
+          AdvanceShipments
+        ]
+
+        def run
+          object.save
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
...sses) could look like

@jordan-brough @cbrunsdon this is my initial attempt at what the order updater interface (and actually general behavior classes that could be used elsewhere) could look like.

I'm opening a pull request not because I want this merged, but because in-line feedback is easier this way.

Something to note, I do think that this replaces all of the current functionality and calculations of the OrderUpdater that exists in 2-2-dev today, though have not yet verified this assertion. As you might expect there were some places that this allowed us to dry things up.

The initial entry point (to replace OrderUpdater) is `Spree::Behaviors::Order::Recalculate.new(order).execute!` or `Spree::Behaviors::Order::Recalculate.new(order).execute`