### PR TITLE
Don't allow return items to be received if another return item has already been received with the same inventory unit

### DIFF
--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -25,7 +25,7 @@ module Spree
     validate :belongs_to_same_customer_order
     validate :validate_acceptance_status_for_reimbursement
     validates :inventory_unit, presence: true
-    validate :validate_no_other_completed_return_items, on: :create
+    validate :validate_no_other_completed_return_items
 
     after_create :cancel_others, unless: :cancelled?
 
@@ -231,9 +231,9 @@ module Spree
       other_return_item = Spree::ReturnItem.where({
         inventory_unit_id: inventory_unit_id,
         reception_status: COMPLETED_RECEPTION_STATUSES,
-      }).first
+      }).where.not(id: self.id).first
 
-      if other_return_item
+      if other_return_item && (new_record? || COMPLETED_RECEPTION_STATUSES.include?(reception_status.to_sym))
         errors.add(:inventory_unit, :other_completed_return_item_exists, {
           inventory_unit_id: inventory_unit_id,
           return_item_id: other_return_item.id,

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -42,6 +42,22 @@ describe Spree::ReturnItem do
       subject
     end
 
+    context 'when there is a received return item with the same inventory unit' do
+      let!(:return_item_with_dupe_inventory_unit) { create(:return_item, inventory_unit: inventory_unit, reception_status: 'received') }
+
+      before do
+        assert_raises(StateMachine::InvalidTransition) { subject }
+      end
+
+      it 'does not receive the return item' do
+        expect(return_item.reception_status).to eq 'awaiting'
+      end
+
+      it 'adds an error to the return item' do
+        expect(return_item.errors[:inventory_unit]).to include "#{return_item.inventory_unit_id} has already been taken by return item #{return_item_with_dupe_inventory_unit.id}"
+      end
+    end
+
     context 'with a stock location' do
       let(:stock_item)      { inventory_unit.find_stock_item }
 


### PR DESCRIPTION
Currently there is some place that is receiving multiple return items with the same inventory unit. This makes for some confusing data.