### PR TITLE
Stop hitting Spree's servers when running specs

### DIFF
--- a/backend/spec/controllers/spree/admin/alerts_spec.rb
+++ b/backend/spec/controllers/spree/admin/alerts_spec.rb
@@ -14,7 +14,7 @@ describe 'alerts' do
   end
 
   before do
-    # Spree::Alert.should_receive(:current).and_return("string")
+    expect(Spree::Alert).to receive(:current).and_return("string")
   end
 
   # Regression test for #3716


### PR DESCRIPTION
I noticed this while running specs offline.
We were hitting Spree's "alert" endpoint every time we ran this backend spec.