### PR TITLE
Clear caches in specs

### DIFF
--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -44,11 +44,13 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.include Spree::Api::TestingSupport::Helpers, :type => :controller
   config.extend Spree::Api::TestingSupport::Setup, :type => :controller
-  config.include Spree::TestingSupport::Preferences, :type => :controller
+  config.include Spree::TestingSupport::Preferences
 
   config.fail_fast = ENV['FAIL_FAST'] || false
 
-  config.before do
+  config.before(:each) do
+    Rails.cache.clear
+    reset_spree_preferences
     Spree::Api::Config[:requires_authentication] = true
   end
 

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -62,6 +62,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     Rails.cache.clear
+    reset_spree_preferences
     WebMock.disable!
     if RSpec.current_example.metadata[:js]
       DatabaseCleaner.strategy = :truncation
@@ -75,7 +76,6 @@ RSpec.configure do |config|
     end
 
     DatabaseCleaner.start
-    reset_spree_preferences
   end
 
   config.after(:each) do

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -74,6 +74,8 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
+    Rails.cache.clear
+    reset_spree_preferences
     WebMock.disable!
     if RSpec.current_example.metadata[:js]
       DatabaseCleaner.strategy = :truncation
@@ -86,7 +88,6 @@ RSpec.configure do |config|
       ActiveRecord::Base.connection.increment_open_transactions
     end
     DatabaseCleaner.start
-    reset_spree_preferences
   end
 
   config.after(:each) do


### PR DESCRIPTION
We were getting obscure test failures and unexpected behavior due to caches (in particular model-preferences caching) not being cleared between spec runs.

Cache clearing was already mostly being done in the various spec_helper's.  This adds:

- Api:
  - Add `Rails.cache.clear` and `reset_spree_preferences`
  - Include TestingSupport::Preferences in all specs, not just controller specs
- Frontend:
  - Add `Rails.cache.clear`
- Standardize where these are called in all the spec_helper's

I benchmarked running the Api specs before and after this change and there was no noticeable difference.