### PR TITLE
Allow stock quantifier to take order stock locations into account

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -79,11 +79,15 @@ module Spree
     end
 
     def sufficient_stock?
-      Stock::Quantifier.new(variant).can_supply? quantity
+      Stock::Quantifier.new(variant, order_stock_locations_for_variant).can_supply? quantity
     end
 
     def insufficient_stock?
       !sufficient_stock?
+    end
+
+    def order_stock_locations_for_variant
+      order.order_stock_locations.where(variant_id: variant_id)
     end
 
     def assign_stock_changes_to=(shipment)

--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -2,7 +2,7 @@ module Spree
   module Stock
     class AvailabilityValidator < ActiveModel::Validator
       def validate(line_item)
-        quantifier = Stock::Quantifier.new(line_item.variant)
+        quantifier = Stock::Quantifier.new(line_item.variant, line_item.order_stock_locations_for_variant)
 
         unless quantifier.can_supply? line_item.quantity
           variant = line_item.variant

--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -3,9 +3,9 @@ module Spree
     class Quantifier
       attr_reader :stock_items
 
-      def initialize(variant)
+      def initialize(variant, order_stock_locations = nil)
         @variant = variant
-        @stock_items = Spree::StockItem.joins(:stock_location).where(:variant_id => @variant, Spree::StockLocation.table_name =>{ :active => true})
+        @stock_items = Spree::StockItem.joins(:stock_location).where(:variant_id => @variant, Spree::StockLocation.table_name => {id: stock_location_ids(order_stock_locations)})
       end
 
       def total_on_hand
@@ -24,6 +24,15 @@ module Spree
         total_on_hand >= required || backorderable?
       end
 
+      private
+
+      def stock_location_ids(order_stock_locations)
+        if order_stock_locations.present?
+          order_stock_locations.pluck(:stock_location_id)
+        else
+          Spree::StockLocation.active.pluck(:id)
+        end
+      end
     end
   end
 end

--- a/core/spec/models/spree/stock/availability_validator_spec.rb
+++ b/core/spec/models/spree/stock/availability_validator_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   module Stock
     describe AvailabilityValidator do
-      let!(:line_item) { double(quantity: 5, variant_id: 1, variant: double.as_null_object, errors: double('errors'), inventory_units: []) }
+      let!(:line_item) { double(quantity: 5, variant_id: 1, variant: double.as_null_object, errors: double('errors'), inventory_units: [], order_stock_locations_for_variant: nil) }
 
       subject { described_class.new(nil) }
 


### PR DESCRIPTION
* If specified use those to make sure the stock items are available for a given quantity and variant

Note: Ultimately, I think the `#sufficient_stock?` check should happen on the order level rather than the line item level. There could be cases in which an order has many line items each with the same variant, each of which can be supplied individually from the stock locations, but when combined the line items would collectively be attempting to pull too much stock for that variant in those locations.

This slight oversight seems to have always been the case, even before introducing order_stock_locations. Their addition could probably make that move to the order level easier, but I'm not sure if that is necessary for this particular pull request. Open to that idea though.