### PR TITLE
Revert "Revert "Add more intermediate return item statuses""

### DIFF
--- a/backend/app/controllers/spree/admin/customer_returns_controller.rb
+++ b/backend/app/controllers/spree/admin/customer_returns_controller.rb
@@ -3,10 +3,9 @@ module Spree
     class CustomerReturnsController < ResourceController
       belongs_to 'spree/order', find_by: :number
 
-      before_filter :parent # ensure order gets loaded to support our pseudo parent-child relationship
-      before_filter :load_form_data, only: [:new, :edit]
-
-      create.before :build_return_items_from_params
+      before_action :parent # ensure order gets loaded to support our pseudo parent-child relationship
+      before_action :load_form_data, only: [:new, :edit]
+      before_action :build_return_items_from_params, only: [:create]
       create.fails  :load_form_data
 
       def edit
@@ -58,6 +57,9 @@ module Spree
           next unless item_params.delete('returned') == '1'
           return_item = item_params[:id] ? Spree::ReturnItem.find(item_params[:id]) : Spree::ReturnItem.new
           return_item.assign_attributes(item_params)
+          if item_params[:reception_status_event].blank?
+            redirect_to(new_object_url, flash: { error: 'Reception status choice required' }) and return
+          end
           return_item
         end.compact
       end

--- a/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
@@ -42,7 +42,7 @@
           <%= item_fields.check_box :resellable, { checked: return_item.resellable } %>
         </td>
         <td class="align-center">
-          <%= item_fields.select :reception_status_event, return_item.available_active_status_paths, {include_blank: false}, {class: 'add-item select2 fullwidth'} %>
+          <%= item_fields.select :reception_status_event, return_item.potential_reception_transitions, {include_blank: true}, {class: 'add-item select2 fullwidth'} %>
         </td>
       </tr>
     <% end %>

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -1,7 +1,7 @@
 module Spree
   class ReturnItem < ActiveRecord::Base
 
-    INTERMEDIATE_RECEPTION_STATUSES = %i(given_to_customer lost_in_transit shipped_wrong_item short_shipped)
+    INTERMEDIATE_RECEPTION_STATUSES = %i(given_to_customer lost_in_transit shipped_wrong_item short_shipped in_transit)
     COMPLETED_RECEPTION_STATUSES = INTERMEDIATE_RECEPTION_STATUSES + [:received]
 
     class_attribute :return_eligibility_validator
@@ -69,6 +69,7 @@ module Spree
       event(:lost) { transition to: :lost_in_transit, from: :awaiting }
       event(:wrong_item_shipped) { transition to: :shipped_wrong_item, from: :awaiting }
       event(:short_shipped) { transition to: :short_shipped, from: :awaiting }
+      event(:in_transit) { transition to: :in_transit, from: :awaiting }
     end
 
     extend DisplayMoney

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -242,7 +242,8 @@ describe Spree::ReturnItem do
     give: 'given_to_customer',
     lost: 'lost_in_transit',
     wrong_item_shipped: 'shipped_wrong_item',
-    short_shipped: 'short_shipped'
+    short_shipped: 'short_shipped',
+    in_transit: 'in_transit'
   }.each do |transition, status|
     describe "##{transition}" do
       let(:return_item) { create(:return_item, reception_status: status, inventory_unit: inventory_unit) }


### PR DESCRIPTION
This reverts commit ae2a8745f05c46c042d46e0608ff43fa14cebb01.

I had forgotten that there was user testing desired here, so I reverted
the original and commited that. Will leave this PR open until the user
testing is completed.