### PR TITLE
Remove some Admin::PaymentsController hooks

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -116,10 +116,12 @@ module Spree
 
     # Returns tuple of payment and whether it saved successfully for now,
     # while we figure out the optimal interface here.
-    def add_payment(payment_params: {}, source_id: nil, payment: nil)
+    def add_payment(payment_params: {}, source_id: nil)
       # not sure why, but apparently the build doesn't make the order available in the payment's before_create hook
-      payment ||= order.payments.build(payment_params.merge(order: order))
-      payment.source = payment.payment_method.payment_source_class.find_by_id(source_id) if source_id
+      payment = order.payments.build(payment_params.merge(order: order))
+      if source_id
+        payment.source = payment.payment_method.payment_source_class.find_by_id(source_id)
+      end
       [payment, payment.save]
     end
 


### PR DESCRIPTION
Spree itself doesn't use these and we don't use these in any extensions either. They make for more convoluted code.

These originally came from gift voucher integration: https://github.com/JDutil/spree/commit/6b8699e. Hopefully we can provide a better way to integrate (probably at a different level) if we find that something like this is needed going forward.

cc @gmacdougall 