### PR TITLE
Don't treat return items with an intermediate reception status as an unreturned exchange.

### DIFF
--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -30,6 +30,7 @@ module Spree
     after_create :cancel_others, unless: :cancelled?
 
     scope :awaiting_return, -> { where(reception_status: 'awaiting') }
+    scope :expecting_return, -> { where.not(reception_status: COMPLETED_RECEPTION_STATUSES) }
     scope :not_cancelled, -> { where.not(reception_status: 'cancelled') }
     scope :given_to_customer, -> { where(reception_status: 'given_to_customer') }
     scope :lost_in_transit, -> { where(reception_status: 'lost_in_transit') }

--- a/core/lib/tasks/exchanges.rake
+++ b/core/lib/tasks/exchanges.rake
@@ -3,7 +3,7 @@ namespace :exchanges do
   the customer for not returning them}
   task charge_unreturned_items: :environment do
 
-    unreturned_return_items =  Spree::ReturnItem.awaiting_return.exchange_processed.joins(:exchange_inventory_unit).where([
+    unreturned_return_items =  Spree::ReturnItem.expecting_return.exchange_processed.joins(:exchange_inventory_unit).where([
       "spree_inventory_units.created_at < :days_ago AND spree_inventory_units.state = :iu_state",
       days_ago: Spree::Config[:expedited_exchanges_days_window].days.ago, iu_state: "shipped"
     ]).to_a

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -5,7 +5,32 @@ describe "exchanges:charge_unreturned_items" do
 
   its(:prerequisites) { should include("environment") }
 
+  before do
+    @original_expedited_exchanges_pref = Spree::Config[:expedited_exchanges]
+    Spree::Config[:expedited_exchanges] = true
+    Spree::StockItem.update_all(count_on_hand: 10)
+  end
+
+  after { Spree::Config[:expedited_exchanges] = @original_expedited_exchanges_pref }
+
   context "there are no unreturned items" do
+    it { expect { subject.invoke }.not_to change { Spree::Order.count } }
+  end
+
+  context "there are return items in an intermediate return status" do
+    let!(:order) { create(:shipped_order, line_items_count: 2) }
+    let(:return_item_1) { build(:exchange_return_item, inventory_unit: order.inventory_units.first) }
+    let(:return_item_2) { build(:exchange_return_item, inventory_unit: order.inventory_units.last) }
+    let!(:rma) { create(:return_authorization, order: order, return_items: [return_item_1, return_item_2]) }
+    let!(:tax_rate) { create(:tax_rate, zone: order.tax_zone, tax_category: return_item_2.exchange_variant.tax_category) }
+    before do
+      rma.save!
+      Spree::Shipment.last.ship!
+      return_item_1.lost!
+      return_item_2.give!
+      Timecop.travel (Spree::Config[:expedited_exchanges_days_window] + 1).days
+    end
+    after { Timecop.return }
     it { expect { subject.invoke }.not_to change { Spree::Order.count } }
   end
 
@@ -17,19 +42,13 @@ describe "exchanges:charge_unreturned_items" do
     let!(:tax_rate) { create(:tax_rate, zone: order.tax_zone, tax_category: return_item_2.exchange_variant.tax_category) }
 
     before do
-      @original_expedited_exchanges_pref = Spree::Config[:expedited_exchanges]
-      Spree::Config[:expedited_exchanges] = true
-      Spree::StockItem.update_all(count_on_hand: 10)
       rma.save!
       Spree::Shipment.last.ship!
       return_item_1.receive!
       Timecop.travel travel_time
     end
 
-    after do
-      Timecop.return
-      Spree::Config[:expedited_exchanges] = @original_expedited_exchanges_pref
-    end
+    after { Timecop.return }
 
     context "fewer than the config allowed days have passed" do
       let(:travel_time) { (Spree::Config[:expedited_exchanges_days_window] - 1).days }


### PR DESCRIPTION
Items that are lost in transit or given to customer should not be deemed
unreturned and not be charged after the allotted time.