### PR TITLE
Remove unused admin/payments routes

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -100,7 +100,7 @@ Spree::Core::Engine.add_routes do
           put :fire
         end
       end
-      resources :payments do
+      resources :payments, only: [:index, :new, :show, :create] do
         member do
           put :fire
         end


### PR DESCRIPTION
Only these four standard routes are defined for Admin::PaymentsController