### PR TITLE
Add validation for line items to have inventory units before order completion

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -567,6 +567,15 @@ module Spree
         end
       end
 
+      def ensure_inventory_units
+        if has_step?("delivery")
+          inventory_validator = Spree::Stock::InventoryValidator.new
+
+          errors = line_items.map { |line_item| inventory_validator.validate(line_item) }.compact
+          raise Spree::LineItem::InsufficientStock if errors.any?
+        end
+      end
+
       def validate_line_item_availability
         availability_validator = Spree::Stock::AvailabilityValidator.new
 

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -77,6 +77,7 @@ module Spree
               # calls matter so that we do not process payments
               # until validations have passed
               before_transition to: :complete, do: :validate_line_item_availability
+              before_transition to: :complete, do: :ensure_inventory_units
               before_transition to: :complete, do: :ensure_available_shipping_rates
 
               if states[:payment]

--- a/core/app/models/spree/stock/inventory_validator.rb
+++ b/core/app/models/spree/stock/inventory_validator.rb
@@ -1,0 +1,14 @@
+module Spree
+  module Stock
+    class InventoryValidator < ActiveModel::Validator
+      def validate(line_item)
+        if line_item.inventory_units.count != line_item.quantity
+          line_item.errors[:inventory] << Spree.t(
+            :inventory_not_available,
+            item: line_item.variant.name
+          )
+        end
+      end
+    end
+  end
+end

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -145,6 +145,7 @@ describe Spree::CheckoutController do
           # An order requires a payment to reach the complete state
           # This is because payment_required? is true on the order
           create(:payment, :amount => order.total, :order => order)
+          order.line_items.each {|li| li.inventory_units.create! }
           order.payments.reload
         end
 


### PR DESCRIPTION
* Added validator which checks the correct number of inventory units have been created for each line item in an order, based on the line item’s inventory. Validation called after stock validation and before payment capture.
* Updated and added spec.