### PR TITLE
Prevent unreturned exchanges from checking stock

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -76,8 +76,8 @@ module Spree
               # Sequence of before_transition to: :complete
               # calls matter so that we do not process payments
               # until validations have passed
-              before_transition to: :complete, do: :validate_line_item_availability
-              before_transition to: :complete, do: :ensure_inventory_units
+              before_transition to: :complete, do: :validate_line_item_availability, unless: :unreturned_exchange?
+              before_transition to: :complete, do: :ensure_inventory_units, unless: :unreturned_exchange?
               before_transition to: :complete, do: :ensure_available_shipping_rates
 
               if states[:payment]

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -362,6 +362,44 @@ describe Spree::Order do
       end
     end
 
+    context "exchange order completion" do
+      before do
+        order.email = 'spree@example.org'
+        order.payments << FactoryGirl.create(:payment)
+        order.shipments.create!
+        order.stub(payment_required?: true)
+        order.stub(:ensure_available_shipping_rates).and_return(true)
+      end
+
+      context 'when the line items are not available' do
+        before do
+          order.line_items << FactoryGirl.create(:line_item)
+          Spree::OrderUpdater.new(order).update
+
+          order.save!
+        end
+
+        context 'when the exchange is for an unreturned item' do
+          before do
+            order.shipments.first.update_attributes!(created_at: order.created_at - 1.day)
+            expect(order.unreturned_exchange?).to eq true
+          end
+
+          it 'allows the order to complete' do
+            order.complete!
+
+            expect(order).to be_complete
+          end
+        end
+
+        context 'when the exchange is not for an unreturned item' do
+          it 'does not allow the order to completed' do
+            expect { order.complete! }.to raise_error  Spree::LineItem::InsufficientStock
+          end
+        end
+      end
+    end
+
     context "default credit card" do
       before do
         order.user = FactoryGirl.create(:user)


### PR DESCRIPTION
Previously, and order made from an unreturned exchange would check for
stock, potentially preventing an order from completing.
* Added a condition to the stock check before transitioning to complete
* Specs