### PR TITLE
Don't pull carts older than the last completed order as current

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -125,7 +125,12 @@ module Spree
         end
 
         def find_current_api_user_orders
-          current_api_user.orders.incomplete.order(:created_at)
+          last_completed_at = current_api_user.orders.complete.order(:completed_at).select(:completed_at).last.try(:completed_at)
+
+          incomplete_orders = current_api_user.orders.incomplete.order(:created_at)
+          incomplete_orders = incomplete_orders.where('created_at > ?', last_completed_at) if last_completed_at
+
+          incomplete_orders
         end
 
         def before_delivery

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -120,6 +120,17 @@ module Spree
         end
       end
 
+      context "a newer complete order exists" do
+        it "does not return the latest incomplete order" do
+          Timecop.travel 1.minute.from_now do
+            new_order = create(:shipped_order, user: order.user)
+            expect(new_order.completed_at).to be > order.created_at
+            expect(subject.status).to eq 204
+            expect(subject.body).to be_blank
+          end
+        end
+      end
+
       context "an incomplete order does not exist" do
 
         before do


### PR DESCRIPTION
Previously, after completing an order it would go back and pull old
abandoned carts for you as your new current cart. This change makes sure
that we don't do that; it'll create a new cart instead.

Fixes ENG-1559