### PR TITLE
Add validation to adjustments for adjustables

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -438,7 +438,7 @@ module Spree
       context "with a line item" do
         let(:order_with_line_items) do
           order = create(:order_with_line_items)
-          create(:adjustment, :adjustable => order)
+          create(:adjustment, order: order, adjustable: order)
           order
         end
 

--- a/backend/app/controllers/spree/admin/adjustments_controller.rb
+++ b/backend/app/controllers/spree/admin/adjustments_controller.rb
@@ -24,7 +24,7 @@ module Spree
       end
 
       def destroy
-        find_adjustment 
+        find_adjustment
         super
       end
 
@@ -41,6 +41,12 @@ module Spree
       def update_totals
         @order.updater.update_adjustment_total
         @order.persist_totals
+      end
+
+      # Override method used to create a new instance to correctly
+      # associate adjustment with order
+      def build_resource
+        parent.adjustments.build(order: parent)
       end
     end
   end

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -33,12 +33,6 @@ describe "Adjustments" do
     click_link "Adjustments"
   end
 
-  after :each do
-    order.reload.all_adjustments.each do |adjustment|
-      expect(adjustment.order_id).to equal(order.id)
-    end
-  end
-
   context "admin managing adjustments" do
     it "should display the correct values for existing order adjustments" do
       within_row(1) do
@@ -64,6 +58,10 @@ describe "Adjustments" do
         click_button "Continue"
         page.should have_content("successfully created!")
         page.should have_content("Total: $90.00")
+
+        order.reload.all_adjustments.each do |adjustment|
+          expect(adjustment.order_id).to equal(order.id)
+        end
       end
     end
 
@@ -109,7 +107,7 @@ describe "Adjustments" do
       end
     end
   end
-  
+
   context "deleting an adjustment" do
     it "should not be possible if adjustment is closed" do
       within_row(1) do

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -20,7 +20,7 @@ describe "Adjustments" do
       :amount => 10)
   end
 
-  let!(:adjustment) { order.adjustments.create!(label: 'Rebate', amount: 10) }
+  let!(:adjustment) { order.adjustments.create!(order: order, label: 'Rebate', amount: 10) }
 
   before(:each) do
     # To ensure the order totals are correct
@@ -31,6 +31,12 @@ describe "Adjustments" do
     click_link "Orders"
     within_row(1) { click_icon :edit }
     click_link "Adjustments"
+  end
+
+  after :each do
+    order.reload.all_adjustments.each do |adjustment|
+      expect(adjustment.order_id).to equal(order.id)
+    end
   end
 
   context "admin managing adjustments" do

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -28,6 +28,7 @@ module Spree
     belongs_to :promotion_code, :class_name => 'Spree::PromotionCode'
 
     validates :adjustable, presence: true
+    validates :order, presence: true
     validates :label, presence: true
     validates :amount, numericality: true
     validates :promotion_code, presence: true, if: :require_promotion_code?
@@ -107,7 +108,7 @@ module Spree
 
     def update_adjustable_adjustment_total
       # Cause adjustable's total to be recalculated
-      Spree::ItemAdjustments.new(adjustable).update if adjustable
+      ItemAdjustments.new(adjustable).update
     end
 
     def require_promotion_code?

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -27,6 +27,7 @@ module Spree
     belongs_to :order, :class_name => "Spree::Order"
     belongs_to :promotion_code, :class_name => 'Spree::PromotionCode'
 
+    validates :adjustable, presence: true
     validates :label, presence: true
     validates :amount, numericality: true
     validates :promotion_code, presence: true, if: :require_promotion_code?

--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -27,7 +27,7 @@ module Spree
       #
       # It also fits the criteria for sales tax as outlined here:
       # http://www.boe.ca.gov/formspubs/pub113/
-      # 
+      #
       # Tax adjustments come in not one but *two* exciting flavours:
       # Included & additional
 

--- a/core/db/migrate/20150227161934_add_order_ids_to_adjustments_where_missing.rb
+++ b/core/db/migrate/20150227161934_add_order_ids_to_adjustments_where_missing.rb
@@ -1,0 +1,9 @@
+class AddOrderIdsToAdjustmentsWhereMissing < ActiveRecord::Migration
+  def up
+    Spree::Adjustment.where(order_id: nil, adjustable_type: 'Spree::Order').update_all("order_id = adjustable_id")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -88,7 +88,7 @@ module Spree
             begin
               adjustment = order.adjustments.build(
                 order:  order,
-                amount: a[:amount].to_f,
+                amount: a[:amount].to_d,
                 label:  a[:label]
               )
               adjustment.save!
@@ -105,7 +105,7 @@ module Spree
             begin
               payment, success = order.contents.add_payment(
                 payment_params: {
-                  amount: p[:amount].to_f,
+                  amount: p[:amount].to_d,
                   state: p.fetch(:state, 'completed'),
                   payment_method: Spree::PaymentMethod.find_by_name!(p[:payment_method])
                 }

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -86,8 +86,11 @@ module Spree
           return [] unless adjustments
           adjustments.each do |a|
             begin
-              adjustment = order.adjustments.build(:amount => a[:amount].to_f,
-                                                  :label => a[:label])
+              adjustment = order.adjustments.build(
+                order:  order,
+                amount: a[:amount].to_f,
+                label:  a[:label]
+              )
               adjustment.save!
               adjustment.close!
             rescue Exception => e

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -118,12 +118,12 @@ describe Spree::Adjustment do
 
         let(:promotion) { create(:promotion, :with_order_adjustment, code: 'somecode') }
         let(:promotion_code) { promotion.codes.first }
-        let(:order) { create(:order_with_line_items, line_items_count: 1) }
+        let(:order1) { create(:order_with_line_items, line_items_count: 1) }
 
         before do
-          promotion.activate(order: order, promotion_code: promotion_code)
-          expect(order.adjustments.size).to eq 1
-          @adjustment = order.adjustments.first
+          promotion.activate(order: order1, promotion_code: promotion_code)
+          expect(order1.adjustments.size).to eq 1
+          @adjustment = order1.adjustments.first
         end
 
         context "the promotion is eligible" do

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -5,17 +5,22 @@ require 'spec_helper'
 
 describe Spree::Adjustment do
 
-  let(:order) { mock_model(Spree::Order, update!: nil) }
-  let(:adjustment) { Spree::Adjustment.create(:label => "Adjustment", :amount => 5) }
+  let(:order) { Spree::Order.new }
+
+  before do
+    allow(order).to receive(:update!)
+  end
+
+  let(:adjustment) { Spree::Adjustment.create!(label: 'Adjustment', adjustable: order, order: order, amount: 5) }
 
   describe 'non_tax scope' do
     subject do
       Spree::Adjustment.non_tax.to_a
     end
 
-    let!(:tax_adjustment) { create(:adjustment, source: create(:tax_rate)) }
-    let!(:non_tax_adjustment_with_source) { create(:adjustment, source_type: 'Spree::Order', source_id: nil) }
-    let!(:non_tax_adjustment_without_source) { create(:adjustment, source: nil) }
+    let!(:tax_adjustment) { create(:adjustment, order: order, source: create(:tax_rate))                   }
+    let!(:non_tax_adjustment_with_source) { create(:adjustment, order: order, source_type: 'Spree::Order', source_id: nil) }
+    let!(:non_tax_adjustment_without_source) { create(:adjustment, order: order, source: nil)                                 }
 
     it 'select non-tax adjustments' do
       expect(subject).to_not include tax_adjustment
@@ -25,7 +30,7 @@ describe Spree::Adjustment do
   end
 
   context "adjustment state" do
-    let(:adjustment) { create(:adjustment, state: 'open') }
+    let(:adjustment) { create(:adjustment, order: order, state: 'open') }
 
     context "#closed?" do
       it "is true when adjustment state is closed" do

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -22,7 +22,7 @@ describe Spree::Calculator::Returns::DefaultRefundAmount do
       let(:adjustment_amount) { -10.0 }
 
       before do
-        order.adjustments << create(:adjustment, amount: adjustment_amount, eligible: true, label: 'Adjustment', source_type: 'Spree::Order')
+        order.adjustments << create(:adjustment, order: order, amount: adjustment_amount, eligible: true, label: 'Adjustment', source_type: 'Spree::Order')
         order.adjustments.first.update_attributes(amount: adjustment_amount)
       end
 

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -10,7 +10,7 @@ module Spree
     context '#update' do
       it "updates a linked adjustment" do
         tax_rate = create(:tax_rate, :amount => 0.05)
-        adjustment = create(:adjustment, :source => tax_rate, :adjustable => line_item)
+        adjustment = create(:adjustment, order: order, source: tax_rate, adjustable: line_item)
         line_item.price = 10
         line_item.tax_category = tax_rate.tax_category
 
@@ -38,14 +38,15 @@ module Spree
         line_item.price = 20
         line_item.tax_category = tax_rate.tax_category
         line_item.save
-        create(:adjustment, :source => promotion_action, :adjustable => line_item)
+        create(:adjustment, :source => promotion_action, :adjustable => line_item, :order => order)
       end
 
       context "tax included in price" do
         before do
-          create(:adjustment, 
+          create(:adjustment,
             :source => tax_rate,
             :adjustable => line_item,
+            :order => order,
             :included => true
           )
         end
@@ -62,9 +63,10 @@ module Spree
 
       context "tax excluded from price" do
         before do
-          create(:adjustment, 
+          create(:adjustment,
             :source => tax_rate,
             :adjustable => line_item,
+            :order => order,
             :included => false
           )
         end

--- a/core/spec/models/spree/order/adjustments_spec.rb
+++ b/core/spec/models/spree/order/adjustments_spec.rb
@@ -6,7 +6,34 @@ describe Spree::Order do
     it "does not show adjustments from other, non-order adjustables" do
       order = Spree::Order.new(:id => 1)
       where_sql = order.all_adjustments.where_values.to_s
-      where_sql.should include("(adjustable_id = 1 AND adjustable_type = 'Spree::Order')")
+      expect(where_sql).to include("(adjustable_id = 1 AND adjustable_type = 'Spree::Order')")
+    end
+  end
+
+  # Regression test for #2191
+  context "when an order has an adjustment that zeroes the total, but another adjustment for shipping that raises it above zero" do
+    let!(:persisted_order) { create(:order) }
+    let!(:line_item) { create(:line_item) }
+    let!(:shipping_method) do
+      sm = create(:shipping_method)
+      sm.calculator.preferred_amount = 10
+      sm.save
+      sm
+    end
+
+    before do
+      # Don't care about available payment methods in this test
+      allow(persisted_order).to receive_messages(:has_available_payment => false)
+      persisted_order.line_items << line_item
+      create(:adjustment, amount: -line_item.amount, label: "Promotion", adjustable: line_item, order: persisted_order)
+      persisted_order.state = 'delivery'
+      persisted_order.save # To ensure new state_change event
+    end
+
+    it "transitions from delivery to payment" do
+      allow(persisted_order).to receive_messages(payment_required?: true)
+      persisted_order.next!
+      expect(persisted_order.state).to eq("payment")
     end
   end
 end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -139,7 +139,7 @@ describe Spree::Order do
         line_item = FactoryGirl.create(:line_item, :price => 10, :adjustment_total => 10)
         order.line_items << line_item
         tax_rate = create(:tax_rate, :tax_category => line_item.tax_category, :amount => 0.05)
-        FactoryGirl.create(:tax_adjustment, :adjustable => line_item, :source => tax_rate)
+        FactoryGirl.create(:tax_adjustment, :adjustable => line_item, :source => tax_rate, order: order)
         order.email = "user@example.com"
         order.next!
         order.adjustment_total.should == 0.5

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -433,7 +433,7 @@ describe Spree::Order do
       # Don't care about available payment methods in this test
       persisted_order.stub(:has_available_payment => false)
       persisted_order.line_items << line_item
-      create(:adjustment, :amount => -line_item.amount, :label => "Promotion", :adjustable => line_item)
+      create(:adjustment, :amount => -line_item.amount, :label => "Promotion", :adjustable => line_item, :order => persisted_order)
       persisted_order.state = 'delivery'
       persisted_order.save # To ensure new state_change event
     end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -43,7 +43,7 @@ module Spree
 
         before do
           updater.update
-          create(:adjustment, :source => promotion_action, :adjustable => order)
+          create(:adjustment, source: promotion_action, adjustable: order, order: order)
           create(:line_item, :order => order, price: 10) # in addition to the two already created
           updater.update
         end

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -10,7 +10,10 @@ module Spree
         let!(:line_item) { create(:line_item, :order => order) }
         let(:payload) { { order: order, promotion: promotion } }
 
-        before { action.stub(:promotion => promotion) }
+        before do
+          allow(action).to receive(:promotion).and_return(promotion)
+          promotion.promotion_actions = [action]
+        end
 
         context "#perform" do
           # Regression test for #3966
@@ -122,7 +125,7 @@ module Spree
 
           it "destroys adjustments for incompleted orders" do
             order = Order.create
-            action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: line_item)
+            action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: order)
 
             expect {
               action.destroy
@@ -131,7 +134,7 @@ module Spree
 
           it "nullifies adjustments for completed orders" do
             order = Order.create(completed_at: Time.now)
-            adjustment = action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: line_item)
+            adjustment = action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: order)
 
             expect {
               action.destroy
@@ -139,7 +142,7 @@ module Spree
           end
 
           it "doesnt mess with unrelated adjustments" do
-            other_action.adjustments.create!(label: "Check", amount: 0, adjustable: line_item)
+            other_action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: order)
 
             expect {
               action.destroy

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -122,7 +122,7 @@ module Spree
 
           it "destroys adjustments for incompleted orders" do
             order = Order.create
-            action.adjustments.create!(label: "Check", amount: 0, order: order)
+            action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: line_item)
 
             expect {
               action.destroy
@@ -131,7 +131,7 @@ module Spree
 
           it "nullifies adjustments for completed orders" do
             order = Order.create(completed_at: Time.now)
-            adjustment = action.adjustments.create!(label: "Check", amount: 0, order: order)
+            adjustment = action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: line_item)
 
             expect {
               action.destroy
@@ -139,7 +139,7 @@ module Spree
           end
 
           it "doesnt mess with unrelated adjustments" do
-            other_action.adjustments.create!(label: "Check", amount: 0)
+            other_action.adjustments.create!(label: "Check", amount: 0, adjustable: line_item)
 
             expect {
               action.destroy

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -21,10 +21,11 @@ describe Spree::PromotionCode do
     let(:promotion) { create(:promotion, :with_order_adjustment, per_code_usage_limit: per_code_usage_limit) }
     let(:promotion_code) { create(:promotion_code, promotion: promotion) }
     let(:promotable) { create(:order) }
+    let(:order) { create(:order) }
 
     context "there is a usage limit set" do
       let!(:existing_adjustment) do
-        Spree::Adjustment.create!(label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code)
+        Spree::Adjustment.create!(label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code, adjustable: order, order: order)
       end
 
       context "the usage limit is not exceeded" do
@@ -46,7 +47,7 @@ describe Spree::PromotionCode do
 
         context "for the same order" do
           let!(:existing_adjustment) do
-            Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code)
+            Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code, order: promotable)
           end
 
           it "returns false" do
@@ -69,8 +70,8 @@ describe Spree::PromotionCode do
     let(:promotable) { create(:order) }
     let(:promotion) { create(:promotion, :with_order_adjustment, code: 'abc123') }
     let(:promotion_code) { promotion.codes.first }
-    let!(:adjustment1) { Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code) }
-    let!(:adjustment2) { Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code) }
+    let!(:adjustment1) { Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code, order: promotable) }
+    let!(:adjustment2) { Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code, order: promotable) }
 
     it "counts the eligible adjustments that have used this promotion" do
       adjustment2.update_columns(eligible: false)

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -285,12 +285,12 @@ describe Spree::Promotion do
     end
 
     let!(:adjustment) do
-      create(
-        :adjustment,
-        source: action,
-        promotion_code: promotion.codes.first,
-        amount: 10,
-        label: "Promotional adjustment",
+      order = create(:order)
+      Spree::Adjustment.create!(
+        :source => action,
+        :adjustable => order,
+        :amount => 10,
+        :label => "Promotional adjustment"
       )
     end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -140,12 +140,13 @@ describe Spree::Promotion do
 
   context "#usage_limit_exceeded?" do
     let(:promotable) { create(:order) }
+    let(:order) { create(:order) }
 
     context "there is a usage limit set" do
       let(:promotion) { create(:promotion, :with_order_adjustment, usage_limit: usage_limit) }
 
       let!(:existing_adjustment) do
-        Spree::Adjustment.create!(label: 'Adjustment', amount: 1, source: promotion.actions.first)
+        Spree::Adjustment.create!(label: 'Adjustment', amount: 1, source: promotion.actions.first, adjustable: order, order: order)
       end
 
       context "the usage limit is not exceeded" do
@@ -167,7 +168,7 @@ describe Spree::Promotion do
 
         context "for the same order" do
           let!(:existing_adjustment) do
-            Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first)
+            Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, order: promotable)
           end
 
           it "returns false" do
@@ -188,8 +189,8 @@ describe Spree::Promotion do
   context "#usage_count" do
     let(:promotable) { create(:order) }
     let(:promotion) { create(:promotion, :with_order_adjustment) }
-    let!(:adjustment1) { Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first) }
-    let!(:adjustment2) { Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first) }
+    let!(:adjustment1) { Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, order: promotable) }
+    let!(:adjustment2) { Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, order: promotable) }
 
     it "counts the eligible adjustments that have used this promotion" do
       adjustment2.update_columns(eligible: false)
@@ -290,6 +291,7 @@ describe Spree::Promotion do
         order:      order,
         adjustable: order,
         source:     action,
+        promotion_code: promotion.codes.first,
         amount:     10,
         label:      'Promotional adjustment'
       )
@@ -322,10 +324,11 @@ describe Spree::Promotion do
     end
 
     context "when the promotion's usage limit is exceeded" do
+      let(:order) { create(:order) }
       let(:promotion) { create(:promotion, :with_order_adjustment) }
 
       before do
-        Spree::Adjustment.create!(label: 'Adjustment', amount: 1, source: promotion.actions.first)
+        Spree::Adjustment.create!(label: 'Adjustment', amount: 1, source: promotion.actions.first, adjustable: order, order: order)
         promotion.usage_limit = 1
       end
 
@@ -335,11 +338,12 @@ describe Spree::Promotion do
     end
 
     context "when the promotion code's usage limit is exceeded" do
+      let(:order) { create(:order) }
       let(:promotion) { create(:promotion, :with_order_adjustment, code: 'abc123', per_code_usage_limit: 1) }
       let(:promotion_code) { promotion.codes.first }
 
       before do
-        Spree::Adjustment.create!(label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code)
+        Spree::Adjustment.create!(label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code, order: order, adjustable: order)
       end
 
       it "returns false" do

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -287,10 +287,11 @@ describe Spree::Promotion do
     let!(:adjustment) do
       order = create(:order)
       Spree::Adjustment.create!(
-        :source => action,
-        :adjustable => order,
-        :amount => 10,
-        :label => "Promotional adjustment"
+        order:      order,
+        adjustable: order,
+        source:     action,
+        amount:     10,
+        label:      'Promotional adjustment'
       )
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -251,7 +251,7 @@ describe Spree::Shipment do
       # Regression test for #4347
       context "with adjustments" do
         before do
-          shipment.adjustments << Spree::Adjustment.create(:label => "Label", :amount => 5)
+          shipment.adjustments << Spree::Adjustment.create(order: order, label: "Label", amount: 5)
         end
 
         it "transitions to shipped" do
@@ -423,23 +423,25 @@ describe Spree::Shipment do
     end
 
     it "factors in additional adjustments to adjustment total" do
-      shipment.adjustments.create!({
-        :label => "Additional",
-        :amount => 5,
-        :included => false,
-        :state => "closed"
-      })
+      shipment.adjustments.create!(
+        order:    order,
+        label:    "Additional",
+        amount:   5,
+        included: false,
+        state:    "closed"
+      )
       shipment.update_amounts
       shipment.reload.adjustment_total.should == 5
     end
 
     it "does not factor in included adjustments to adjustment total" do
-      shipment.adjustments.create!({
-        :label => "Included",
-        :amount => 5,
-        :included => true,
-        :state => "closed"
-      })
+      shipment.adjustments.create!(
+        order:    order,
+        label:    "Included",
+        amount:   5,
+        included: true,
+        state:    "closed"
+      )
       shipment.update_amounts
       shipment.reload.adjustment_total.should == 0
     end

--- a/sample/db/samples/adjustments.rb
+++ b/sample/db/samples/adjustments.rb
@@ -6,6 +6,7 @@ last_order = Spree::Order.find_by_number!("R987654321")
 first_order.adjustments.create!(
   :amount => 0,
   :source => Spree::TaxRate.find_by_name!("North America"),
+  :order  => first_order,
   :label => "Tax",
   :state => "open",
   :mandatory => true)
@@ -13,6 +14,7 @@ first_order.adjustments.create!(
 last_order.adjustments.create!(
   :amount => 0,
   :source => Spree::TaxRate.find_by_name!("North America"),
+  :order  => last_order,
   :label => "Tax",
   :state => "open",
   :mandatory => true)


### PR DESCRIPTION
This was preventing some order totals from being updating, resulting in the order state reflecting incorrectly.