### PR TITLE
Initial modeling and schema for multi-code promotions

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -25,6 +25,7 @@ module Spree
     belongs_to :adjustable, polymorphic: true
     belongs_to :source, polymorphic: true
     belongs_to :order, :class_name => "Spree::Order"
+    belongs_to :promotion_code, :class_name => 'Spree::PromotionCode'
 
     validates :label, presence: true
     validates :amount, numericality: true
@@ -40,6 +41,7 @@ module Spree
     end
 
     after_create :update_adjustable_adjustment_total
+    before_save :update_promotion_code
 
     scope :open, -> { where(state: 'open') }
     scope :closed, -> { where(state: 'closed') }
@@ -104,6 +106,13 @@ module Spree
     def update_adjustable_adjustment_total
       # Cause adjustable's total to be recalculated
       Spree::ItemAdjustments.new(adjustable).update if adjustable
+    end
+
+    # Temporary to make sure data is getting written correctly
+    def update_promotion_code
+      if promotion? && source.promotion.try(:promotion_code).present?
+        self.promotion_code = source.promotion.promotion_code
+      end
     end
   end
 end

--- a/core/app/models/spree/order_promotion.rb
+++ b/core/app/models/spree/order_promotion.rb
@@ -1,0 +1,23 @@
+# Spree::OrderPromotion represents the relationship between:
+# 1. A promotion that a user attempted to apply to their order
+# 2. The specific code that they used
+module Spree
+  class OrderPromotion < ActiveRecord::Base
+    self.table_name = 'spree_orders_promotions'
+
+    belongs_to :order, class_name: 'Spree::Order'
+    belongs_to :promotion, class_name: 'Spree::Promotion'
+    belongs_to :promotion_code, class_name: 'Spree::PromotionCode'
+
+    before_save :update_promotion_code
+
+    private
+
+    # Temporary to make sure data is getting written correctly
+    def update_promotion_code
+      if promotion.present? && promotion.promotion_code.present?
+        self.promotion_code = promotion.promotion_code
+      end
+    end
+  end
+end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -11,7 +11,10 @@ module Spree
     has_many :promotion_actions, autosave: true, dependent: :destroy
     alias_method :actions, :promotion_actions
 
-    has_and_belongs_to_many :orders, join_table: 'spree_orders_promotions'
+    has_many :order_promotions, class_name: 'Spree::OrderPromotion'
+    has_many :orders, through: :order_promotions
+
+    has_one :promotion_code, class_name: 'Spree::PromotionCode'
 
     accepts_nested_attributes_for :promotion_actions, :promotion_rules
 
@@ -23,6 +26,7 @@ module Spree
     validates :description, length: { maximum: 255 }
 
     before_save :normalize_blank_values
+    before_save :update_promotion_code_value
 
     def self.advertised
       where(advertise: true)
@@ -146,6 +150,16 @@ module Spree
     def normalize_blank_values
       [:code, :path].each do |column|
         self[column] = nil if self[column].blank?
+      end
+    end
+
+    def update_promotion_code_value
+      if code.present?
+        if promotion_code.present?
+          promotion_code.update_attributes(value: code)
+        else
+          build_promotion_code(value: code, usage_limit: usage_limit)
+        end
       end
     end
 

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -1,0 +1,8 @@
+class Spree::PromotionCode < ActiveRecord::Base
+  belongs_to :promotion
+  has_many :adjustments
+
+  validates :usage_limit, numericality: { greater_than: 0, allow_nil: true }
+  validates :value, presence: true, uniqueness: true
+  validates :promotion_id, presence: true
+end

--- a/core/db/migrate/20150113002122_create_spree_promotion_codes.rb
+++ b/core/db/migrate/20150113002122_create_spree_promotion_codes.rb
@@ -1,0 +1,13 @@
+class CreateSpreePromotionCodes < ActiveRecord::Migration
+  def change
+    create_table :spree_promotion_codes do |t|
+      t.references :promotion, index: true, null: false
+      t.string :value, null: false
+      t.integer :usage_limit
+
+      t.timestamps
+    end
+
+    add_index :spree_promotion_codes, :value, unique: true
+  end
+end

--- a/core/db/migrate/20150113002123_create_adjustment_promotion_code_association.rb
+++ b/core/db/migrate/20150113002123_create_adjustment_promotion_code_association.rb
@@ -1,0 +1,6 @@
+class CreateAdjustmentPromotionCodeAssociation < ActiveRecord::Migration
+  def change
+    add_column :spree_adjustments, :promotion_code_id, :integer
+    add_index :spree_adjustments, :promotion_code_id
+  end
+end

--- a/core/db/migrate/20150213160148_add_promotion_code_id_to_orders_promotions.rb
+++ b/core/db/migrate/20150213160148_add_promotion_code_id_to_orders_promotions.rb
@@ -1,0 +1,7 @@
+class AddPromotionCodeIdToOrdersPromotions < ActiveRecord::Migration
+  def change
+    add_column :spree_orders_promotions, :promotion_code_id, :integer
+    add_index :spree_orders_promotions, :promotion_code_id
+    add_column :spree_orders_promotions, :id, :primary_key
+  end
+end


### PR DESCRIPTION
Step 1 for multi-code promotions:
* Promotion has one promotion code
* Adjustment belongs to promotion code
* Order promotions belongs to promotion code
* When updating `SpreePromotion#code`, write to `Spree::PromotionCode`
* Do not read from `Spree::PromotionCode`