### PR TITLE
Fix for multi-code promos - don't copy usage_limit

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -156,9 +156,9 @@ module Spree
     def update_promotion_code_value
       if code.present?
         if promotion_code.present?
-          promotion_code.update_attributes(value: code)
+          promotion_code.update_attributes!(value: code)
         else
-          build_promotion_code(value: code, usage_limit: usage_limit)
+          build_promotion_code(value: code)
         end
       end
     end


### PR DESCRIPTION
And add a `!` to a method.