### PR TITLE
Multi-promos: Move all reads for Promotion#code to PromotionCode#value

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -120,7 +120,7 @@ module Spree
 
       @@adjustment_attributes = [
         :id, :source_type, :source_id, :adjustable_type, :adjustable_id,
-        :originator_type, :originator_id, :amount, :label, :mandatory,
+        :originator_type, :originator_id, :amount, :label, :mandatory, :promotion_code,
         :locked, :eligible,  :created_at, :updated_at
       ]
 

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -72,7 +72,7 @@
         </div>
         <div class="field">
           <%= label_tag nil, Spree.t(:promotion) %>
-          <%= f.text_field :promotions_code_cont, :size => 25 %>
+          <%= f.text_field :promotions_promotion_code_value_cont, :size => 25 %>
         </div>
       </div>
 

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -28,7 +28,7 @@
       <div class="four columns">
         <div class="field">
           <%= label_tag nil, 'code' %>
-          <%= f.text_field :code_cont, tabindex: 1 %>
+          <%= f.text_field :promotion_code_value_cont, tabindex: 1 %>
         </div>
       </div>
 

--- a/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
@@ -31,7 +31,7 @@ describe Spree::Admin::PromotionsController do
       end
 
       it "filters by code" do
-        spree_get :index, q: {code_cont: promotion1.code}
+        spree_get :index, q: {promotion_code_value_cont: promotion1.code}
         expect(assigns[:promotions].map(&:id)).to eq [promotion1.id]
       end
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -101,7 +101,7 @@ describe "Orders Listing" do
       end
 
       it "only shows the orders with the selected promotion" do
-        fill_in "q_promotions_code_cont", with: promotion.code
+        fill_in "q_promotions_promotion_code_value_cont", with: promotion.code
         click_icon :search
         within_row(1) { page.should have_content("R100") }
         within("table#listing_orders") { page.should_not have_content("R200") }

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -26,14 +26,11 @@ module Spree
     validates :description, length: { maximum: 255 }
 
     before_save :normalize_blank_values
-    before_save :update_promotion_code_value
+
+    after_save :save_promotion_code
 
     def self.advertised
       where(advertise: true)
-    end
-
-    def self.with_coupon_code(coupon_code)
-      where("lower(#{quoted_table_name}.code) = ?", coupon_code.strip.downcase).first
     end
 
     def self.active
@@ -45,8 +42,26 @@ module Spree
       order && !UNACTIVATABLE_ORDER_STATES.include?(order.state)
     end
 
+    # Temporarily keeping the same interface for promotion codes while using
+    # promotion_codes table.
+    def code
+      promotion_code.try!(:value)
+    end
+    def code=(val)
+      if promotion_code
+        promotion_code.value = val
+      else
+        build_promotion_code(value: val) if val.present?
+      end
+    end
+
     def expired?
-      !!(starts_at && Time.now < starts_at || expires_at && Time.now > expires_at)
+      !active?
+    end
+
+    def active?
+      (starts_at.nil? || starts_at < Time.now) &&
+        (expires_at.nil? || expires_at > Time.now)
     end
 
     def activate(payload)
@@ -148,19 +163,11 @@ module Spree
     end
 
     def normalize_blank_values
-      [:code, :path].each do |column|
-        self[column] = nil if self[column].blank?
-      end
+      self[:path] = nil if self[:path].blank?
     end
 
-    def update_promotion_code_value
-      if code.present?
-        if promotion_code.present?
-          promotion_code.update_attributes!(value: code)
-        else
-          build_promotion_code(value: code)
-        end
-      end
+    def save_promotion_code
+      promotion_code.save! if promotion_code.present?
     end
 
     def match_all?

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -29,6 +29,11 @@ module Spree
 
     after_save :save_promotion_code
 
+    # temporary code. remove after the column is dropped from the db.
+    def columns
+      super.reject { |column| column.name == 'code' }
+    end
+
     def self.advertised
       where(advertise: true)
     end

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -5,4 +5,12 @@ class Spree::PromotionCode < ActiveRecord::Base
   validates :usage_limit, numericality: { greater_than: 0, allow_nil: true }
   validates :value, presence: true, uniqueness: true
   validates :promotion_id, presence: true
+
+  before_save :downcase_value
+
+  private
+
+  def downcase_value
+    self.value = value.downcase
+  end
 end

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -31,16 +31,22 @@ module Spree
       private
         def promotions
           promo_table = Promotion.arel_table
+          code_table  = PromotionCode.arel_table
           join_table = Arel::Table.new(:spree_orders_promotions)
 
           join_condition = promo_table.join(join_table, Arel::Nodes::OuterJoin).on(
             promo_table[:id].eq(join_table[:promotion_id])
           ).join_sources
 
+          promotion_code_condition = promo_table.join(code_table, Arel::Nodes::OuterJoin).on(
+            promo_table[:id].eq(code_table[:promotion_id])
+          ).join_sources
+
           Promotion.active.includes(:promotion_rules).
+            joins(promotion_code_condition).
             joins(join_condition).
             where(
-              promo_table[:code].eq(nil).and(
+              code_table[:value].eq(nil).and(
                 promo_table[:path].eq(nil)
               ).or(join_table[:order_id].eq(order.id))
             ).distinct

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -30,25 +30,29 @@ module Spree
 
       private
         def promotions
+          connected_order_promotions | sale_promotions
+        end
+
+        def connected_order_promotions
+          Promotion.active.includes(:promotion_rules).
+            joins(:order_promotions).
+            where(spree_orders_promotions: { order_id: order.id }).readonly(false).to_a
+        end
+
+        def sale_promotions
           promo_table = Promotion.arel_table
           code_table  = PromotionCode.arel_table
-          join_table = Arel::Table.new(:spree_orders_promotions)
 
-          join_condition = promo_table.join(join_table, Arel::Nodes::OuterJoin).on(
-            promo_table[:id].eq(join_table[:promotion_id])
-          ).join_sources
-
-          promotion_code_condition = promo_table.join(code_table, Arel::Nodes::OuterJoin).on(
+          promotion_code_join = promo_table.join(code_table, Arel::Nodes::OuterJoin).on(
             promo_table[:id].eq(code_table[:promotion_id])
           ).join_sources
 
           Promotion.active.includes(:promotion_rules).
-            joins(promotion_code_condition).
-            joins(join_condition).
+            joins(promotion_code_join).
             where(
               code_table[:value].eq(nil).and(
                 promo_table[:path].eq(nil)
-              ).or(join_table[:order_id].eq(order.id))
+              )
             ).distinct
         end
     end

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -13,7 +13,7 @@ module Spree
           if promotion.present? && promotion.actions.exists?
             handle_present_promotion(promotion)
           else
-            if Promotion.with_coupon_code(order.coupon_code).try(:expired?)
+            if promotion_code && promotion_code.promotion.expired?
               self.error = Spree.t(:coupon_code_expired)
             else
               self.error = Spree.t(:coupon_code_not_found)
@@ -25,7 +25,11 @@ module Spree
       end
 
       def promotion
-        @promotion ||= Promotion.active.includes(:promotion_rules, :promotion_actions).with_coupon_code(order.coupon_code)
+        @promotion ||= begin
+          if promotion_code && promotion_code.promotion.active?
+            promotion_code.promotion
+          end
+        end
       end
 
       def successful?
@@ -33,6 +37,10 @@ module Spree
       end
 
       private
+
+      def promotion_code
+        @promotion_code ||= Spree::PromotionCode.where(value: order.coupon_code.downcase).first
+      end
 
       def handle_present_promotion(promotion)
         return promotion_usage_limit_exceeded if promotion.usage_limit_exceeded?(order)

--- a/core/app/models/spree/promotion_handler/free_shipping.rb
+++ b/core/app/models/spree/promotion_handler/free_shipping.rb
@@ -23,14 +23,14 @@ module Spree
           promo_table = Promotion.arel_table
           code_table  = PromotionCode.arel_table
 
-          promotion_code_condition = promo_table.join(code_table, Arel::Nodes::OuterJoin).on(
+          promotion_code_join = promo_table.join(code_table, Arel::Nodes::OuterJoin).on(
             promo_table[:id].eq(code_table[:promotion_id])
           ).join_sources
 
-          Spree::Promotion.
-            joins(promotion_code_condition).
+          Spree::Promotion.active.
+            joins(promotion_code_join).
             where({
-              id: Spree::Promotion::Actions::FreeShipping.pluck(:promotion_id),
+              id: Spree::Promotion::Actions::FreeShipping.pluck(:promotion_id), # This would probably be more efficient by joining instead
               spree_promotion_codes: { id: nil },
               path: nil
             })

--- a/core/app/models/spree/promotion_handler/free_shipping.rb
+++ b/core/app/models/spree/promotion_handler/free_shipping.rb
@@ -20,11 +20,20 @@ module Spree
       private
 
         def promotions
-          Spree::Promotion.active.where({
-            :id => Spree::Promotion::Actions::FreeShipping.pluck(:promotion_id),
-            :code => nil,
-            :path => nil
-          })
+          promo_table = Promotion.arel_table
+          code_table  = PromotionCode.arel_table
+
+          promotion_code_condition = promo_table.join(code_table, Arel::Nodes::OuterJoin).on(
+            promo_table[:id].eq(code_table[:promotion_id])
+          ).join_sources
+
+          Spree::Promotion.
+            joins(promotion_code_condition).
+            where({
+              id: Spree::Promotion::Actions::FreeShipping.pluck(:promotion_id),
+              spree_promotion_codes: { id: nil },
+              path: nil
+            })
         end
     end
   end

--- a/core/db/migrate/20150226195213_downcase_promotion_codes_values.rb
+++ b/core/db/migrate/20150226195213_downcase_promotion_codes_values.rb
@@ -1,0 +1,10 @@
+class DowncasePromotionCodesValues < ActiveRecord::Migration
+  def up
+    Spree::PromotionCode.update_all("value = lower(value)")
+    Spree::Promotion.where.not(code: nil).update_all("code = lower(code)")
+  end
+
+  def down
+    # Not reversible
+  end
+end

--- a/core/db/migrate/20150226195213_downcase_promotion_codes_values.rb
+++ b/core/db/migrate/20150226195213_downcase_promotion_codes_values.rb
@@ -5,6 +5,7 @@ class DowncasePromotionCodesValues < ActiveRecord::Migration
   end
 
   def down
-    # Not reversible
+    # can't tell which things we updated vs what things were like before
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Spree::PromotionCode do
+  context 'callbacks' do
+    subject { promotion_code.save }
+
+    describe '#downcase_value' do
+      let(:promotion) { create(:promotion, code: 'NewCoDe') }
+      let(:promotion_code) { promotion.promotion_code }
+
+      it 'downcases the value before saving' do
+        subject
+        expect(promotion_code.value).to eq('newcode')
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -158,7 +158,7 @@ describe Spree::Promotion do
     end
 
     it "should not be expired if current time is within starts_at and expires_at range" do
-      promotion.expires_at = Time.now - 1.day
+      promotion.starts_at = Time.now - 1.day
       promotion.expires_at = Time.now + 1.day
       promotion.should_not be_expired
     end
@@ -167,6 +167,44 @@ describe Spree::Promotion do
       promotion.usage_limit = 2
       promotion.stub(:credits_count => 1)
       promotion.should_not be_expired
+    end
+  end
+
+  context "#active" do
+    it "should be active" do
+      expect(promotion.active?).to eq(true)
+    end
+
+    it "should not be active if it hasn't started yet" do
+      promotion.starts_at = Time.now + 1.day
+      expect(promotion.active?).to eq(false)
+    end
+
+    it "should not be active if it has already ended" do
+      promotion.expires_at = Time.now - 1.day
+      expect(promotion.active?).to eq(false)
+    end
+
+    it "should be active if it has started already" do
+      promotion.starts_at = Time.now - 1.day
+      expect(promotion.active?).to eq(true)
+    end
+
+    it "should be active if it has not ended yet" do
+      promotion.expires_at = Time.now + 1.day
+      expect(promotion.active?).to eq(true)
+    end
+
+    it "should be active if current time is within starts_at and expires_at range" do
+      promotion.starts_at = Time.now - 1.day
+      promotion.expires_at = Time.now + 1.day
+      expect(promotion.active?).to eq(true)
+    end
+
+    it "should be active if there are no start and end times set" do
+      promotion.starts_at = nil
+      promotion.expires_at = nil
+      expect(promotion.active?).to eq(true)
     end
   end
 
@@ -365,21 +403,10 @@ describe Spree::Promotion do
 
   # regression for #4059
   # admin form posts the code and path as empty string
-  describe "normalize blank values for code & path" do
+  describe "normalize blank values for path" do
     it "will save blank value as nil value instead" do
-      promotion = Spree::Promotion.create(:name => "A promotion", :code => "", :path => "")
-      expect(promotion.code).to be_nil
+      promotion = Spree::Promotion.create(:name => "A promotion", :path => "")
       expect(promotion.path).to be_nil
-    end
-  end
-
-  # Regression test for #4081
-  describe "#with_coupon_code" do
-    context "and code stored in uppercase" do
-      let!(:promotion) { create(:promotion, :code => "MY-COUPON-123") }
-      it "finds the code with lowercase" do
-        expect(Spree::Promotion.with_coupon_code("my-coupon-123")).to eql promotion
-      end
     end
   end
 


### PR DESCRIPTION
* Admin searches uses associated promotion_code value
* All reads and writes on `Spree::Promotion#code` will defer to `Spree::PromotionCode#value`
* Update callback on `Spree::Promotion` to save the associated code instead of updating its value (temporary)
* Promotion Handlers now read from the spree_promotion_codes table
* Add callback to `Spree::PromotionCode` to downcase all values so we don't have to constantly match against casing
* Added `#active?` to `Spree::Promotion` and refactored `#expired?`. Added tests
* Added promotion_code to the API for adjustments