### PR TITLE
Allow admins to bulk update promotion code usage limits

### DIFF
--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -4,6 +4,7 @@ module Spree
       before_filter :load_data
 
       create.before :build_promotion_codes
+      update.before :bulk_update_limits
 
       helper 'spree/promotion_rules'
 
@@ -19,6 +20,14 @@ module Spree
               number_of_codes: @bulk_number,
               usage_limit: @bulk_limit,
             )
+          end
+        end
+
+        def bulk_update_limits
+          @bulk_limit = Integer(params[:bulk_limit]) if params[:bulk_limit].present?
+
+          if @bulk_limit && @promotion.codes.present?
+            @promotion.codes.map{|code| code.update!(usage_limit: @bulk_limit) }
           end
         end
 

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -17,11 +17,11 @@
           <%= label_tag :number_of_codes %>
           <%= text_field_tag "bulk_number", @bulk_number, class: 'fullwidth' %>
         <% end %>
+      <% end %>
 
-        <%= f.field_container :per_code_usage_limit do %>
-          <%= label_tag :per_code_usage_limit %>
-          <%= text_field_tag "bulk_limit", @bulk_limit, class: 'fullwidth' %>
-        <% end %>
+      <%= f.field_container :per_code_usage_limit do %>
+        <%= label_tag :per_code_usage_limit %>
+        <%= text_field_tag "bulk_limit", @promotion.codes.first.try(:usage_limit), class: 'fullwidth' %>
       <% end %>
 
       <%= f.field_container :path do %>

--- a/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
@@ -42,6 +42,29 @@ describe Spree::Admin::PromotionsController do
     end
   end
 
+  describe "#update" do
+    let(:params) { {id: promotion.id, promotion: {name: 'some promo'}} }
+    let(:promotion) { create(:promotion, code: 'abc123') }
+
+    before { promotion.codes.first.update!(usage_limit: 100) }
+
+    context "when bulk limit is provided" do
+      let(:params) { super().merge(bulk_limit: 1) }
+
+      it "updates the usage limit on all the codes" do
+        spree_post :update, params
+        expect(promotion.codes.map(&:usage_limit).uniq).to eq [1]
+      end
+    end
+
+    context "when bulk limit is not provided" do
+      it "does not update the codes' usage limits" do
+        spree_post :update, params
+        expect(promotion.codes.map(&:usage_limit).uniq).to eq [100]
+      end
+    end
+  end
+
   describe "#create" do
     let(:params) { {promotion: {name: 'some promo'}} }
 


### PR DESCRIPTION
Now they can set the code-level usage limits as well as the overall usage limits after the promotion has been created