### PR TITLE
Use Spree.ajax for Spree api ajax requests.

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/adjustments.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/adjustments.js.coffee
@@ -1,13 +1,13 @@
 $(@).ready( ->
   $('[data-hook=adjustments_new_coupon_code] #add_coupon_code').click ->
     return if $("#coupon_code").val().length == 0
-    $.ajax
+    Spree.ajax
       type: 'PUT'
-      url: Spree.url(Spree.routes.orders_api + '/' + order_number + '/apply_coupon_code.json');
+      url: Spree.routes.orders_api + '/' + order_number + '/apply_coupon_code.json'
       data:
         coupon_code: $("#coupon_code").val()
       success: ->
-        window.location.reload();
+        window.location.reload()
       error: (msg) ->
         if msg.responseJSON["error"]
           show_flash 'error', msg.responseJSON["error"]

--- a/backend/app/assets/javascripts/spree/backend/admin.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/admin.js.erb
@@ -131,7 +131,7 @@ $(document).ready(function(){
     ajax_indicator = $(this).data("ajax-indicator") || '#busy_indicator';
     $(target).hide();
     $(ajax_indicator).show();
-    $.ajax({ dataType: 'html',
+    Spree.ajax({ dataType: 'html',
              url: $(this).data("base-url")+encodeURIComponent($(this).val()),
              type: 'get',
              success: function(data){
@@ -165,7 +165,7 @@ $(document).ready(function(){
   $('body').on('click', '.delete-resource', function() {
     var el = $(this);
     if (confirm(el.data("confirm"))) {
-      $.ajax({
+      Spree.ajax({
         type: 'POST',
         url: $(this).prop("href"),
         data: {
@@ -193,7 +193,7 @@ $(document).ready(function(){
     if (el.prop("href").substr(-1) == '#') {
       el.parents("tr").fadeOut('hide');
     }else if (el.prop("href")) {
-      $.ajax({
+      Spree.ajax({
         type: 'POST',
         url: el.prop("href"),
         data: {
@@ -215,7 +215,7 @@ $(document).ready(function(){
   $('body').on('click', '.select_properties_from_prototype', function(){
     $("#busy_indicator").show();
     var clicked_link = $(this);
-    $.ajax({ dataType: 'script', url: clicked_link.prop("href"), type: 'get',
+    Spree.ajax({ dataType: 'script', url: clicked_link.prop("href"), type: 'get',
         success: function(data){
           clicked_link.parent("td").parent("tr").hide();
           $("#busy_indicator").hide();
@@ -249,7 +249,7 @@ $(document).ready(function(){
               positions['positions['+parts[2]+']'] = position;
             }
           });
-          $.ajax({
+          Spree.ajax({
             type: 'POST',
             dataType: 'script',
             url: $(ui.item).closest("table.sortable").data("sortable-link"),
@@ -277,10 +277,10 @@ $(document).ready(function(){
   });
 
   window.Spree.advanceOrder = function() {
-      $.ajax({
+      Spree.ajax({
           type: "PUT",
           async: false,
-          url: Spree.url(Spree.routes.checkouts_api + "/" + order_number + "/advance")
+          url: Spree.routes.checkouts_api + "/" + order_number + "/advance",
       }).done(function() {
           window.location.reload();
       });

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -17,6 +17,7 @@ $(document).ready(function() {
       placeholder: Spree.translations.choose_a_customer,
       ajax: {
         url: Spree.routes.user_search,
+        headers: { "X-Spree-Token": Spree.api_key },
         datatype: 'json',
         data: function(term, page) {
           return { q: term }

--- a/backend/app/assets/javascripts/spree/backend/images/index.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/images/index.js.coffee
@@ -5,7 +5,7 @@ $ ->
     ($ '.no-objects-found').hide()
 
     ($ this).hide()
-    $.ajax
+    Spree.ajax
       type: 'GET'
       url: @href
       data: (

--- a/backend/app/assets/javascripts/spree/backend/line_items.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/line_items.js.coffee
@@ -40,9 +40,9 @@ lineItemURL = (line_item_id) ->
 
 adjustLineItem = (line_item_id, quantity) ->
   url = lineItemURL(line_item_id)
-  $.ajax(
+  Spree.ajax(
     type: "PUT",
-    url: Spree.url(url),
+    url: url,
     data:
       line_item:
         quantity: quantity
@@ -51,9 +51,9 @@ adjustLineItem = (line_item_id, quantity) ->
 
 deleteLineItem = (line_item_id) ->
   url = lineItemURL(line_item_id)
-  $.ajax(
+  Spree.ajax(
     type: "DELETE"
-    url: Spree.url(url)
+    url: url
   ).done (msg) ->
     $('#line-item-' + line_item_id).remove()
     if $('.line-items tr.line-item').length == 0

--- a/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js.erb
@@ -51,9 +51,9 @@ addVariant = function() {
 adjustLineItems = function(order_number, variant_id, quantity, stock_location_quantities){
     var url = Spree.routes.orders_api + "/" + order_number + '/line_items';
 
-    $.ajax({
+    Spree.ajax({
         type: "POST",
-        url: Spree.url(url),
+        url: url,
         data: { line_item: {variant_id: variant_id, quantity: quantity,  stock_location_quantities: stock_location_quantities}}
     }).done(function( msg ) {
         window.Spree.advanceOrder();

--- a/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js.erb
@@ -9,7 +9,7 @@ $(document).ready(function () {
         var url = Spree.url(Spree.routes.option_type_search, {
           ids: element.val()
         });
-        return $.getJSON(url, null, function (data) {
+        return Spree.getJSON(url, null, function (data) {
           return callback(data);
         });
       },
@@ -17,12 +17,10 @@ $(document).ready(function () {
         url: Spree.routes.option_type_search,
         quietMillis: 200,
         datatype: 'json',
+        headers: { "X-Spree-Token": Spree.api_key },
         data: function (term) {
           return {
-            q: {
-              name_cont: term
-            },
-            token: Spree.api_key
+            q: { name_cont: term }
           };
         },
         results: function (data) {

--- a/backend/app/assets/javascripts/spree/backend/option_value_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/option_value_picker.js
@@ -19,6 +19,7 @@ $.fn.optionValueAutocomplete = function (options) {
     ajax: {
       url: Spree.routes.option_value_search,
       datatype: 'json',
+      headers: { "X-Spree-Token": Spree.api_key },
       data: function (term, page) {
         var productId = typeof(productSelect) !== 'undefined' ? $(productSelect).select2('val') : null;
         return {

--- a/backend/app/assets/javascripts/spree/backend/orders/edit_form.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/edit_form.js
@@ -7,14 +7,14 @@ $(document).ready(function () {
 
       var id = '#' + $(this).prop('id').replace('_quantity', '_id');
 
-      $.post('/admin/orders/' + $('input#order_number').val() + '/line_items/' + $(id).val(), {
-          _method: 'put',
-          'line_item[quantity]': $(this).val()
-        },
-
-        function (resp) {
+      Spree.ajax({
+        url: "/admin/orders/" + $('input#order_number').val() + '/line_items/' + $(id).val(),
+        method: "PUT",
+        data: { "line_item": { "quantity": $(this).val() } },
+        always: function (resp) {
           $('#order-form-wrapper').html(resp.responseText);
-        });
+        }
+      });
     });
   });
 });

--- a/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
@@ -2,8 +2,8 @@ jQuery ($) ->
   # Payment model
   class Payment
     constructor: (id) ->
-      @url  = Spree.url("#{Spree.routes.payments_api}/#{id}.json")
-      @json = $.getJSON @url.toString(), (data) =>
+      @url  = "#{Spree.routes.payments_api}/#{id}.json"
+      @json = Spree.getJSON @url, (data) =>
         @data = data
 
     if_pending: (callback) ->
@@ -11,9 +11,9 @@ jQuery ($) ->
         callback() if data.state is 'pending'
 
     update: (attributes, success) ->
-      jqXHR = $.ajax
+      jqXHR = Spree.ajax
         type: 'PUT'
-        url:  @url.toString()
+        url:  @url
         data: { payment: attributes }
       jqXHR.done (data) =>
         @data = data

--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -18,6 +18,7 @@ $.fn.productAutocomplete = function (options) {
     ajax: {
       url: Spree.routes.product_search,
       datatype: 'json',
+      headers: { "X-Spree-Token": Spree.api_key },
       data: function (term, page) {
         return {
           q: {

--- a/backend/app/assets/javascripts/spree/backend/shipments.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js.erb
@@ -62,8 +62,8 @@ $(document).ready(function () {
   $('[data-hook=admin_shipment_form] a.ship').on('click', function () {
     var link = $(this);
     var shipment_number = link.data('shipment-number');
-    var url = Spree.url(Spree.routes.shipments_api + '/' + shipment_number + '/ship.json');
-    $.ajax({
+    var url = Spree.routes.shipments_api + '/' + shipment_number + '/ship.json';
+    Spree.ajax({
       type: 'PUT',
       url: url
     }).done(function () {
@@ -82,9 +82,9 @@ $(document).ready(function () {
     var link = $(this);
     var shipment_number = link.data('shipment-number');
     var selected_shipping_rate_id = link.parents('tbody').find("select#selected_shipping_rate_id[data-shipment-number='" + shipment_number + "']").val();
-    var url = Spree.url(Spree.routes.shipments_api + '/' + shipment_number + '.json');
+    var url = Spree.routes.shipments_api + '/' + shipment_number + '.json';
 
-    $.ajax({
+    Spree.ajax({
       type: 'PUT',
       url: url,
       data: {
@@ -108,9 +108,9 @@ $(document).ready(function () {
     var link = $(this);
     var shipment_number = link.data('shipment-number');
     var tracking = link.parents('tbody').find('input#tracking').val();
-    var url = Spree.url(Spree.routes.shipments_api + '/' + shipment_number + '.json');
+    var url = Spree.routes.shipments_api + '/' + shipment_number + '.json';
 
-    $.ajax({
+    Spree.ajax({
       type: 'PUT',
       url: url,
       data: {
@@ -144,9 +144,9 @@ adjustShipmentItems = function(shipment_number, variant_id, quantity){
     url += '.json';
 
     if(new_quantity!=0){
-      $.ajax({
+      Spree.ajax({
         type: "PUT",
-        url: Spree.url(url),
+        url: url,
         data: { variant_id: variant_id, quantity: new_quantity }
       }).done(function( msg ) {
         Spree.advanceOrder();
@@ -190,10 +190,10 @@ startItemSplit = function(event){
   var variant_id = link.data('variant-id');
 
   var variant = {};
-  $.ajax({
+  Spree.ajax({
     type: "GET",
     async: false,
-    url: Spree.url(Spree.routes.variants_api),
+    url: Spree.routes.variants_api,
     data: {
       q: {
         "id_eq": variant_id
@@ -244,10 +244,10 @@ completeItemSplit = function(event) {
   if (stock_location_id != 'new_shipment') {
     if (new_shipment != undefined) {
       // TRANSFER TO A NEW LOCATION
-      $.ajax({
+      Spree.ajax({
         type: "POST",
         async: false,
-        url: Spree.url(Spree.routes.shipments_api + "/transfer_to_location"),
+        url: Spree.routes.shipments_api + "/transfer_to_location",
         data: {
             original_shipment_number: original_shipment_number,
             variant_id: variant_id,
@@ -261,10 +261,10 @@ completeItemSplit = function(event) {
       });
     } else {
         // TRANSFER TO AN EXISTING SHIPMENT
-        $.ajax({
+        Spree.ajax({
             type: "POST",
             async: false,
-            url: Spree.url(Spree.routes.shipments_api + "/transfer_to_shipment"),
+            url: Spree.routes.shipments_api + "/transfer_to_shipment",
             data: {
                 original_shipment_number: original_shipment_number,
                 target_shipment_number: target_shipment_number,
@@ -302,9 +302,9 @@ addVariantFromStockLocation = function() {
   });
 
   if(shipment==undefined){
-    $.ajax({
+    Spree.ajax({
       type: "POST",
-      url: Spree.url(Spree.routes.shipments_api + "?shipment[order_id]=" + order_number),
+      url: Spree.routes.shipments_api + "?shipment[order_id]=" + order_number,
       data: { variant_id: variant_id, quantity: quantity, stock_location_id: stock_location_id }
     }).done(function( msg ) {
       Spree.advanceOrder();

--- a/backend/app/assets/javascripts/spree/backend/stock_management.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management.js.coffee
@@ -2,7 +2,7 @@ jQuery ->
   $('.stock_item_backorderable').on 'click', ->
     $(@).parent('form').submit()
   $('.toggle_stock_item_backorderable').on 'submit', ->
-    $.ajax
+    Spree.ajax
       type: @method
       url: @action
       data: $(@).serialize()

--- a/backend/app/assets/javascripts/spree/backend/stock_movement.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_movement.js.coffee
@@ -2,7 +2,8 @@ jQuery ->
   $('#stock_movement_stock_item_id').select2
     placeholder: "Find a stock item" # translate
     ajax:
-      url: Spree.url(Spree.routes.stock_items_api)
+      url: Spree.routes.stock_items_api
+      headers: { "X-Spree-Token": Spree.api_key }
       data: (term, page) ->
         q:
           variant_product_name_cont: term

--- a/backend/app/assets/javascripts/spree/backend/stock_transfer.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfer.js.coffee
@@ -30,7 +30,7 @@ $ ->
 
       $('#transfer_receive_stock').change (event) => @receive_stock_change(event)
 
-      $.getJSON Spree.url(Spree.routes.stock_locations_api), (data) =>
+      Spree.getJSON Spree.routes.stock_locations_api, (data) =>
         @locations = (location for location in data.stock_locations)
         @force_receive_stock() if @locations.length < 2
 
@@ -90,13 +90,13 @@ $ ->
       if @cached_variants?
         @populate_select @cached_variants
       else
-        $.getJSON Spree.url(Spree.routes.variants_api), (data) =>
+        Spree.getJSON Spree.routes.variants_api, (data) =>
           @cached_variants = _.map(data.variants, (variant) -> new TransferVariant(variant))
           @populate_select @cached_variants
 
     _refresh_transfer_stock_items: ->
       stock_location_id = $('#transfer_source_location_id').val()
-      $.getJSON Spree.url(Spree.routes.stock_locations_api + "/#{stock_location_id}/stock_items"), (data) =>
+      Spree.getJSON Spree.routes.stock_locations_api + "/#{stock_location_id}/stock_items", (data) =>
         @populate_select _.map(data.stock_items, (stock_item) -> new TransferStockItem(stock_item))
 
     populate_select: (variants) ->

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
@@ -6,15 +6,14 @@ $(document).ready(function () {
       placeholder: Spree.translations.taxon_placeholder,
       multiple: true,
       initSelection: function (element, callback) {
-        var url = Spree.url(Spree.routes.taxons_search, {
-          ids: element.val()
-        });
-        return $.getJSON(url, null, function (data) {
+        var url = Spree.routes.taxons_search + "?ids=" + element.val();
+        return Spree.getJSON(url, null, function (data) {
           return callback(data['taxons']);
         });
       },
       ajax: {
         url: Spree.routes.taxons_search,
+        headers: { "X-Spree-Token": Spree.api_key },
         datatype: 'json',
         data: function (term, page) {
           return {

--- a/backend/app/assets/javascripts/spree/backend/taxon_tree_menu.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxon_tree_menu.js.coffee
@@ -2,10 +2,9 @@ root = exports ? this
 
 root.taxon_tree_menu = (obj, context) ->
 
-  base_url = Spree.url(Spree.routes.taxonomy_taxons_path)
-  admin_base_url = Spree.url(Spree.routes.admin_taxonomy_taxons_path)
-  edit_url = admin_base_url.clone()
-  edit_url.setPath(edit_url.path() + '/' + obj.attr("id") + "/edit");
+  base_url = Spree.routes.taxonomy_taxons_path
+  admin_base_url = Spree.routes.admin_taxonomy_taxons_path
+  edit_url = "#{admin_base_url}/#{obj.attr("id")}/edit"
 
   create:
     label: "<i class='fa fa-plus'></i> " + Spree.translations.add,
@@ -19,4 +18,4 @@ root.taxon_tree_menu = (obj, context) ->
   edit:
     separator_before: true,
     label: "<i class='fa fa-edit'></i> " + Spree.translations.edit,
-    action: (obj) -> window.location = edit_url.toString()
+    action: (obj) -> window.location = edit_url

--- a/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
@@ -8,12 +8,11 @@ handle_move = (e, data) ->
   node = data.rslt.o
   new_parent = data.rslt.np
 
-  url = Spree.url(base_url).clone()
-  url.setPath url.path() + '/' + node.prop("id")
-  $.ajax
+  url = "#{base_url}/#{node.prop("id")}"
+  Spree.ajax
     type: "POST",
     dataType: "json",
-    url: url.toString(),
+    url: url,
     data: ({_method: "put", "taxon[parent_id]": new_parent.prop("id"), "taxon[child_index]": position }),
     error: handle_ajax_error
 
@@ -26,7 +25,7 @@ handle_create = (e, data) ->
   position = data.rslt.position
   new_parent = data.rslt.parent
 
-  $.ajax
+  Spree.ajax
     type: "POST",
     dataType: "json",
     url: base_url.toString(),
@@ -40,27 +39,25 @@ handle_rename = (e, data) ->
   node = data.rslt.obj
   name = data.rslt.new_name
 
-  url = Spree.url(base_url).clone()
-  url.setPath(url.path() + '/' + node.prop("id"))
+  url = "#{base_url}/#{node.prop("id")}"
 
-  $.ajax
+  Spree.ajax
     type: "POST",
     dataType: "json",
-    url: url.toString(),
+    url: url,
     data: {_method: "put", "taxon[name]": name },
     error: handle_ajax_error
 
 handle_delete = (e, data) ->
   last_rollback = data.rlbk
   node = data.rslt.obj
-  delete_url = base_url.clone()
-  delete_url.setPath delete_url.path() + '/' + node.prop("id")
+  delete_url = "#{base_url}/#{node.prop("id")}"
   jConfirm Spree.translations.are_you_sure_delete, Spree.translations.confirm_delete, (r) ->
     if r
-      $.ajax
+      Spree.ajax
         type: "POST",
         dataType: "json",
-        url: delete_url.toString(),
+        url: delete_url,
         data: {_method: "delete"},
         error: handle_ajax_error
     else
@@ -71,10 +68,10 @@ root = exports ? this
 root.setup_taxonomy_tree = (taxonomy_id) ->
   if taxonomy_id != undefined
     # this is defined within admin/taxonomies/edit
-    root.base_url = Spree.url(Spree.routes.taxonomy_taxons_path)
+    root.base_url = Spree.routes.taxonomy_taxons_path
 
-    $.ajax
-      url: Spree.url(base_url.path().replace("/taxons", "/jstree")).toString(),
+    Spree.ajax
+      url: base_url.replace("/taxons", "/jstree"),
       success: (taxonomy) ->
         last_rollback = null
 
@@ -83,10 +80,10 @@ root.setup_taxonomy_tree = (taxonomy_id) ->
             data: taxonomy,
             ajax:
               url: (e) ->
-                Spree.url(base_url.path() + '/' + e.prop('id') + '/jstree').toString()
+                "#{base_url}/#{e.prop('id')}/jstree"
           themes:
             theme: "apple",
-            url: Spree.url(Spree.routes.jstree_theme_path)
+            url: Spree.routes.jstree_theme_path
           strings:
             new_node: new_taxon,
             loading: Spree.translations.loading + "..."

--- a/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
@@ -2,7 +2,7 @@ $(document).ready ->
   window.productTemplate = Handlebars.compile($('#product_template').text());
   $('#taxon_products').sortable();
   $('#taxon_products').on "sortstop", (event, ui) ->
-    $.ajax
+    Spree.ajax
       url: Spree.routes.classifications_api,
       method: 'PUT',
       data:
@@ -17,6 +17,7 @@ $(document).ready ->
       ajax:
         url: Spree.routes.taxons_search,
         datatype: 'json',
+        headers: { "X-Spree-Token": Spree.api_key },
         data: (term, page) ->
           per_page: 50,
           page: page,
@@ -33,7 +34,7 @@ $(document).ready ->
 
   $('#taxon_id').on "change", (e) ->
     el = $('#taxon_products')
-    $.ajax
+    Spree.ajax
       url: Spree.routes.taxon_products_api,
       data:
         id: e.val

--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -14,6 +14,7 @@ $.fn.userAutocomplete = function () {
     ajax: {
       url: Spree.routes.user_search,
       datatype: 'json',
+      headers: { "X-Spree-Token": Spree.api_key },
       data: function (term) {
         return {
           q: term

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee.erb
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee.erb
@@ -18,8 +18,9 @@ $.fn.variantAutocomplete = ->
       $.get Spree.routes.variants_search + "/" + element.val(), {}, (data) ->
         callback data
     ajax:
-      url: Spree.url(Spree.routes.variants_api)
+      url: Spree.routes.variants_api
       datatype: "json"
+      headers: { "X-Spree-Token": Spree.api_key }
       data: (term, page) ->
         q:
           product_name_or_sku_cont: term

--- a/backend/app/assets/javascripts/spree/backend/variant_management.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/variant_management.js.coffee
@@ -3,7 +3,7 @@ jQuery ->
     $(@).siblings('.variant_track_inventory').val($(@).is(':checked'))
     $(@).parent('form').submit()
   $('.toggle_variant_track_inventory').on 'submit', ->
-    $.ajax
+    Spree.ajax
       type: @method
       url: @action
       data: $(@).serialize()

--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -23,8 +23,9 @@
 
 <%= javascript_tag do -%>
   jQuery.alerts.dialogClass = 'spree';
-  <%== "var AUTH_TOKEN = #{form_authenticity_token.inspect};" %>
-  <%== "$.ajaxSetup({'headers': { 'X-Spree-Token': '#{try_spree_current_user.spree_api_key}' }});" if try_spree_current_user %>
+  var AUTH_TOKEN = "<%= form_authenticity_token %>";
+  Spree.api_key = "<%= try_spree_current_user.try(:spree_api_key) %>";
+  Spree.env = "<%= Rails.env %>";
 <% end %>
 
 <%= yield :head %>

--- a/backend/app/views/spree/admin/shared/_translations.html.erb
+++ b/backend/app/views/spree/admin/shared/_translations.html.erb
@@ -1,4 +1,7 @@
 <script>
+  if (Spree === undefined) {
+    var Spree = {}
+  }
   Spree.translations = <%==
   { :date_picker    => Spree.t(:js_format,
                               :scope => 'date_picker',

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -31,7 +31,7 @@ group :test do
   gem 'selenium-webdriver', '~> 2.35'
   gem 'simplecov'
   gem 'webmock', '1.8.11'
-  gem 'poltergeist', '1.5.0'
+  gem 'poltergeist'
   gem 'timecop'
   gem 'with_model'
 end

--- a/frontend/app/assets/javascripts/spree/frontend/cart.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/cart.js.coffee
@@ -9,7 +9,7 @@ Spree.ready ($) ->
     ($ 'form#update-cart #update-button').attr('disabled', true)
 
 Spree.fetch_cart = ->
-  $.ajax
+  Spree.ajax
     url: Spree.routes.cart_link,
     success: (data) ->
       $('#link-to-cart').html data

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
@@ -52,18 +52,15 @@ Spree.onPayment = () ->
         else
           coupon_status = $("#coupon_status")
 
-        url = Spree.url(Spree.routes.apply_coupon_code(Spree.current_order_id),
-          {
+        coupon_status.removeClass()
+        Spree.ajax({
+          async: false,
+          method: "PUT",
+          url: Spree.routes.apply_coupon_code(Spree.current_order_id),
+          data: {
             order_token: Spree.current_order_token,
             coupon_code: coupon_code
           }
-        )
-
-        coupon_status.removeClass();
-        $.ajax({
-          async: false,
-          method: "PUT",
-          url: url,
           success: (data) ->
             coupon_code_field.val('')
             coupon_status.addClass("success").html("Coupon code applied successfully.")


### PR DESCRIPTION
 Rather than setting it as the default for ajax requests, so that we don't send the api key to remote services.