### PR TITLE
Add timestamps to spree_orders_promotions

### DIFF
--- a/core/db/migrate/20150304211616_add_timestamps_to_order_promotions.rb
+++ b/core/db/migrate/20150304211616_add_timestamps_to_order_promotions.rb
@@ -1,0 +1,6 @@
+class AddTimestampsToOrderPromotions < ActiveRecord::Migration
+  def change
+    add_column :spree_orders_promotions, :created_at, :datetime
+    add_column :spree_orders_promotions, :updated_at, :datetime
+  end
+end


### PR DESCRIPTION
Noticed that the timestamps weren't on the table yesterday, would have been helpful for debugging