### PR TITLE
Show code information on admin promotion edit panel

### DIFF
--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -2,6 +2,7 @@ module Spree
   module Admin
     class PromotionsController < ResourceController
       before_filter :load_data
+      before_filter :load_bulk_code_information, only: [:edit]
 
       create.before :build_promotion_codes
 
@@ -18,6 +19,11 @@ module Spree
               number_of_codes: @bulk_number,
             )
           end
+        end
+
+        def load_bulk_code_information
+          @bulk_base = @promotion.codes.first.try!(:value)
+          @bulk_number = @promotion.codes.count
         end
 
         def location_after_save

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -7,16 +7,14 @@
         <%= f.text_field :name, :class => 'fullwidth' %>
       <% end %>
 
-      <% if @promotion.new_record? %>
-        <%= f.field_container :base_code do %>
-          <%= label_tag :base_code %>
-          <%= text_field_tag "bulk_base", @bulk_base, :class => 'fullwidth' %>
-        <% end %>
+      <%= f.field_container :base_code do %>
+        <%= label_tag :base_code %>
+        <%= text_field_tag "bulk_base", @bulk_base, :readonly => !@promotion.new_record?, :class => 'fullwidth' %>
+      <% end %>
 
-        <%= f.field_container :number_of_codes do %>
-          <%= label_tag :number_of_codes %>
-          <%= text_field_tag "bulk_number", @bulk_number, class: 'fullwidth' %>
-        <% end %>
+      <%= f.field_container :number_of_codes do %>
+        <%= label_tag :number_of_codes %>
+        <%= text_field_tag "bulk_number", @bulk_number, :readonly => !@promotion.new_record?, class: 'fullwidth' %>
       <% end %>
 
       <%= f.field_container :per_code_usage_limit do %>


### PR DESCRIPTION
There seems to be confusion about what the code is and how many there are when looking at the promotion#edit page. This allows for a quick look at what the promotion has set up on it.

* Always show the base code and number of codes fields
* On edit: Show first code's value, show how many codes, make them uneditable

