### PR TITLE
Add a frontend option to hide the confirm step

### DIFF
--- a/core/app/helpers/spree/checkout_helper.rb
+++ b/core/app/helpers/spree/checkout_helper.rb
@@ -6,6 +6,10 @@ module Spree
 
     def checkout_progress
       states = checkout_states
+      if Spree::Frontend::Config.hide_confirm_step && !@order.confirm?
+        states -= ['confirm']
+      end
+
       items = states.map do |state|
         text = Spree.t("order_state.#{state}").titleize
 

--- a/frontend/app/models/spree/frontend_configuration.rb
+++ b/frontend/app/models/spree/frontend_configuration.rb
@@ -1,5 +1,6 @@
 module Spree
   class FrontendConfiguration < Preferences::Configuration
     preference :locale, :string, :default => Rails.application.config.i18n.default_locale
+    preference :hide_confirm_step, :boolean, default: false
   end
 end


### PR DESCRIPTION
- Add a frontend "hide_confirm_step" option to allow hiding the
confirm step in the UI
- Don't show the confirm step in the frontend nav
  - unless the order somehow got stuck in that state. similar to what
  the previous spree code did:
  https://github.com/spree/spree/blob/bc81e0d/core/app/models/spree/order.rb#L200)
- Have the "confirm" transition happen behind the scenes without user
interaction for frontend usage.

cc @cbrunsdon @jhawthorn @gmacdougall @athal7 