### PR TITLE
Fix spec

### DIFF
--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -896,7 +896,7 @@ describe Spree::Order do
 
   describe "#unreturned_exchange?" do
     let(:order) { create(:order_with_line_items) }
-    subject { order.unreturned_exchange? }
+    subject { order.reload.unreturned_exchange? }
 
     context "the order does not have a shipment" do
       before { order.shipments.destroy_all }


### PR DESCRIPTION
An in-memory timestamp was being compared to a db-truncated timestamp and
giving unexpected results.  Specifically, it was often failing when run on CircleCI.

It might be better to:

1. Find a more general solution to this so it doesn't bite us elsewhere.
2. Provide a more explicit way to record unreturned exchanges than comparing
timestamp fields values.

But I couldn't think of something great for 1, and 2 would expand the scope of
this a lot.  I'm definitely open to ideas though.

More details:  An in-memory order.created_at timestamp was being compared to a
db-truncated shipment.created_at timestamp.  Rails' sql adapter truncates
database times at the microsecond level because Time#usec truncates instead of
rounding:

https://github.com/rails/rails/blob/v4.0.13/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb#L163

e.g.:

    >> Time.at(0.19999999999).usec
    => 199999