### PR TITLE
Fix flaky spec

### DIFF
--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -56,10 +56,13 @@ module Spree
                 before { rule.stub(:actionable?).and_return(true) }
 
                 it "creates an adjustment" do
-                  action.perform(payload)
-                  expect(action.adjustments.count).to eq 1
-                  expect(line_item.adjustments.count).to eq 1
-                  expect(action.adjustments.first).to eq line_item.adjustments.first
+                  expect {
+                    expect {
+                      action.perform(payload)
+                    }.to change { action.adjustments.count }.by(1)
+                  }.to change { line_item.adjustments.count }.by(1)
+
+                  expect(action.adjustments.last).to eq line_item.adjustments.last
                 end
               end
 
@@ -67,9 +70,11 @@ module Spree
                 before { rule.stub(:actionable?).and_return(false) }
 
                 it "does not create an adjustment" do
-                  action.perform(payload)
-                  expect(action.adjustments.count).to eq 0
-                  expect(line_item.adjustments.count).to eq 0
+                  expect {
+                    expect {
+                      action.perform(payload)
+                    }.to_not change { action.adjustments.count }
+                  }.to_not change { line_item.adjustments.count }
                 end
               end
             end

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -48,19 +48,29 @@ module Spree
             end
 
             context "with products rules" do
-              let!(:second_line_item) { create(:line_item, :order => order) }
               let(:rule) { double Spree::Promotion::Rules::Product }
 
-              before do
-                promotion.stub(:eligible_rules) { [rule] }
-                rule.stub(:actionable?).and_return(true, false)
+              before { promotion.stub(:eligible_rules) { [rule] } }
+
+              context "when the rule is actionable" do
+                before { rule.stub(:actionable?).and_return(true) }
+
+                it "creates an adjustment" do
+                  action.perform(payload)
+                  expect(action.adjustments.count).to eq 1
+                  expect(line_item.adjustments.count).to eq 1
+                  expect(action.adjustments.first).to eq line_item.adjustments.first
+                end
               end
 
-              it "does not create an adjustmenty for line_items not in product rule" do
-                action.perform(payload)
-                expect(action.adjustments.count).to eql 1
-                expect(line_item.reload.adjustments).to match_array action.adjustments
-                expect(second_line_item.reload.adjustments).to be_empty
+              context "when the rule is not actionable" do
+                before { rule.stub(:actionable?).and_return(false) }
+
+                it "does not create an adjustment" do
+                  action.perform(payload)
+                  expect(action.adjustments.count).to eq 0
+                  expect(line_item.adjustments.count).to eq 0
+                end
               end
             end
 


### PR DESCRIPTION
This spec expected line items to be operated on in "id asc" order.  Postgres
doesn't default to "id asc" sort order when it isn't specified and so this was
sometimes failing.  I changed the specs to not rely on sort order.