### PR TITLE
Make best-promotion query more deterministic

### DIFF
--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -71,7 +71,7 @@ module Spree
     end
 
     def best_promotion_adjustment
-      @best_promotion_adjustment ||= adjustments.promotion.eligible.reorder("amount ASC, created_at DESC").first
+      @best_promotion_adjustment ||= adjustments.promotion.eligible.reorder("amount ASC, created_at DESC, id DESC").first
     end
   end
 end

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -115,6 +115,20 @@ module Spree
         line_item.adjustments.promotion.eligible.first.label.should == 'Promotion C'
       end
 
+      it "should choose the most recent promotion adjustment when amounts are equal" do
+        # Using Timecop is a regression test
+        Timecop.freeze do
+          create_adjustment("Promotion A", -200)
+          create_adjustment("Promotion B", -200)
+        end
+        line_item.adjustments.each {|a| a.update_column(:eligible, true)}
+
+        subject.choose_best_promotion_adjustment
+
+        line_item.adjustments.promotion.eligible.count.should == 1
+        line_item.adjustments.promotion.eligible.first.label.should == 'Promotion B'
+      end
+
       context "when previously ineligible promotions become available" do
         let(:order_promo1) { create(:promotion, :with_order_adjustment, :with_item_total_rule, weighted_order_adjustment_amount: 5, item_total_threshold_amount: 10) }
         let(:order_promo2) { create(:promotion, :with_order_adjustment, :with_item_total_rule, weighted_order_adjustment_amount: 10, item_total_threshold_amount: 20) }


### PR DESCRIPTION
This is cherry-picked from https://github.com/spree/spree/commit/ecd181b.  It fixes some spec failures I was seeing [here](https://github.com/bonobos/spree/blob/c06a732/core/spec/models/spree/promotion_handler/coupon_spec.rb#L163-L169).

----------

Mostly for the benefit of the specs.

This query can become non-deterministic when the amounts and created_at
timestamps of two promotion adjustments are the equal.  I believe this is most
likely to happen in the specs.  Especially in MySQL since MySQL does not store
fractional seconds.  We also saw the same behavior in Postgres when running
specs on CircleCI.

Timecop helps repro this issue.