### PR TITLE
Add TestingSupport::Mail

### DIFF
--- a/core/lib/spree/testing_support/mail.rb
+++ b/core/lib/spree/testing_support/mail.rb
@@ -1,0 +1,20 @@
+module Spree
+  module TestingSupport
+    module Mail
+      def with_test_mail
+        old_value = ActionMailer::Base.delivery_method
+        ActionMailer::Base.delivery_method = :test
+        ActionMailer::Base.deliveries.clear
+        begin
+          yield
+        ensure
+          ActionMailer::Base.delivery_method = old_value
+        end
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.extend Spree::TestingSupport::Mail
+end

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -36,6 +36,7 @@ end
 
 require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'
+require 'spree/testing_support/mail'
 
 RSpec.configure do |config|
   config.color = true
@@ -56,6 +57,7 @@ RSpec.configure do |config|
 
   config.include FactoryGirl::Syntax::Methods
   config.include Spree::TestingSupport::Preferences
+  config.include Spree::TestingSupport::Mail
 
   config.fail_fast = ENV['FAIL_FAST'] || false
 end


### PR DESCRIPTION
To make testing emails easier.
Once this is in our branch:
https://github.com/spree/spree/commit/bc3dee0dd46f6840d237ac41a36951514adf37f5
we won't need this anymore.

We encountered this while working on Cartons.

cc @jhawthorn @cbrunsdon 