### PR TITLE
Make order factory more correct

### DIFF
--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -64,7 +64,7 @@ FactoryGirl.define do
             after(:create) do |order|
               order.shipments.each do |shipment|
                 shipment.inventory_units.each { |u| u.update_column('state', 'shipped') }
-                shipment.update_column('state', 'shipped')
+                shipment.update_columns(state: 'shipped', shipped_at: Time.now)
               end
               order.reload
             end


### PR DESCRIPTION
Shipped shipments should have shipped_at timestamps.  I noticed this while
working on some new shipment-related specs.