### PR TITLE
Active model promotion build

### DIFF
--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -19,10 +19,10 @@ module Spree
         @promotion = builder.promotion
 
         if builder.perform
-          flash[:success] = builder.success_messages
+          flash[:success] = Spree.t(:successfully_created, resource: promotion.class.model_name.human)
           redirect_to location_after_save
         else
-          flash[:error] = builder.error_messages
+          flash[:error] = builder.errors.full_messages.join(", ")
           render action: 'new'
         end
       end

--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -12,14 +12,18 @@ module Spree
         @bulk_base = params[:bulk_base].presence
         @bulk_number = params[:bulk_number].presence.try!(:to_i)
 
-        builder = Spree::PromotionBuilder.new(promotion_attrs: permitted_resource_params,
-                                              base_code: @bulk_base,
-                                              number_of_codes: @bulk_number,
-                                              user: spree_current_user)
-        @promotion = builder.promotion
+        @builder = Spree::PromotionBuilder.new(
+          permitted_resource_params,
+          {
+            number_of_codes: @bulk_number,
+            base_code: @bulk_base,
+            user: spree_current_user
+          }
+        )
+        @promotion = @builder.promotion
 
         if builder.perform
-          flash[:success] = Spree.t(:successfully_created, resource: promotion.class.model_name.human)
+          flash[:success] = Spree.t(:successfully_created, resource: @promotion.class.model_name.human)
           redirect_to location_after_save
         else
           flash[:error] = builder.errors.full_messages.join(", ")

--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -15,7 +15,7 @@ module Spree
         )
         @promotion = @promotion_builder.promotion
 
-        if @promotion_builder.valid? && @promotion_builder.perform
+        if @promotion_builder.perform
           flash[:success] = Spree.t(:successfully_created, resource: @promotion.class.model_name.human)
           redirect_to location_after_save
         else

--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -9,32 +9,27 @@ module Spree
       helper 'spree/promotion_rules'
 
       def create
-        @bulk_base = params[:bulk_base].presence
-        @bulk_number = params[:bulk_number].presence.try!(:to_i)
-
-        @builder = Spree::PromotionBuilder.new(
+        @promotion_builder = Spree::PromotionBuilder.new(
+          permitted_promo_builder_params.merge(user: spree_current_user),
           permitted_resource_params,
-          {
-            number_of_codes: @bulk_number,
-            base_code: @bulk_base,
-            user: spree_current_user
-          }
         )
-        @promotion = @builder.promotion
+        @promotion = @promotion_builder.promotion
 
-        if builder.perform
+        if @promotion_builder.valid? && @promotion_builder.perform
           flash[:success] = Spree.t(:successfully_created, resource: @promotion.class.model_name.human)
           redirect_to location_after_save
         else
-          flash[:error] = builder.errors.full_messages.join(", ")
+          flash[:error] = @promotion_builder.errors.full_messages.join(", ")
           render action: 'new'
         end
       end
 
       protected
         def load_bulk_code_information
-          @bulk_base = @promotion.codes.first.try!(:value)
-          @bulk_number = @promotion.codes.count
+          @promotion_builder = Spree::PromotionBuilder.new(
+            base_code: @promotion.codes.first.try!(:value),
+            number_of_codes: @promotion.codes.count,
+          )
         end
 
         def location_after_save
@@ -63,6 +58,14 @@ module Spree
 
         def promotion_includes
           [:promotion_actions]
+        end
+
+        def permitted_promo_builder_params
+          if params[:promotion_builder]
+            params[:promotion_builder].permit(:base_code, :number_of_codes)
+          else
+            {}
+          end
         end
     end
   end

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -7,14 +7,16 @@
         <%= f.text_field :name, :class => 'fullwidth' %>
       <% end %>
 
-      <%= f.field_container :base_code do %>
-        <%= label_tag :base_code %>
-        <%= text_field_tag "bulk_base", @bulk_base, :readonly => !@promotion.new_record?, :class => 'fullwidth' %>
-      <% end %>
+      <%= fields_for :promotion_builder do |bf| %>
+        <%= bf.field_container :base_code do %>
+          <%= bf.label :base_code %>
+          <%= bf.text_field :base_code, :readonly => !@promotion.new_record?, :class => 'fullwidth' %>
+        <% end %>
 
-      <%= f.field_container :number_of_codes do %>
-        <%= label_tag :number_of_codes %>
-        <%= text_field_tag "bulk_number", @bulk_number, :readonly => !@promotion.new_record?, class: 'fullwidth' %>
+        <%= bf.field_container :number_of_codes do %>
+          <%= bf.label :number_of_codes %>
+          <%= bf.text_field :number_of_codes, :readonly => !@promotion.new_record?, class: 'fullwidth' %>
+        <% end %>
       <% end %>
 
       <%= f.field_container :per_code_usage_limit do %>

--- a/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
@@ -63,7 +63,7 @@ describe Spree::Admin::PromotionsController do
 
       context "with one promo codes" do
         let(:params) do
-          super().merge(bulk_base: 'abc', bulk_number: 1)
+          super().merge(promotion_builder: { base_code: 'abc', number_of_codes: 1 })
         end
 
         it "succeeds and creates one code" do
@@ -79,7 +79,7 @@ describe Spree::Admin::PromotionsController do
 
       context "with multiple promo codes" do
         let(:params) do
-          super().merge(bulk_base: 'abc', bulk_number: 2)
+          super().merge(promotion_builder: { base_code: 'abc', number_of_codes: 2 })
         end
 
         before { srand 123 }

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -12,8 +12,8 @@ describe "Promotion Adjustments" do
 
     it "should allow an admin to create a flat rate discount coupon promo" do
       fill_in "Name", :with => "Promotion"
-      fill_in "bulk_base", :with => "order"
-      fill_in "bulk_number", :with => "1"
+      fill_in "Base code", :with => "order"
+      fill_in "Number of codes", :with => "1"
       click_button "Create"
       page.should have_content("Editing Promotion")
 
@@ -48,8 +48,8 @@ describe "Promotion Adjustments" do
     it "should allow an admin to create a single user coupon promo with flat rate discount" do
       fill_in "Name", :with => "Promotion"
       fill_in "promotion[usage_limit]", :with => "1"
-      fill_in "bulk_base", :with => "single_use"
-      fill_in "bulk_number", :with => "1"
+      fill_in "Base code", :with => "single_use"
+      fill_in "Number of codes", :with => "1"
       click_button "Create"
       page.should have_content("Editing Promotion")
 

--- a/core/app/models/spree/promotion_builder.rb
+++ b/core/app/models/spree/promotion_builder.rb
@@ -1,7 +1,8 @@
 class Spree::PromotionBuilder
   include ActiveModel::Model
 
-  attr_reader :promotion, :base_code, :number_of_codes
+  attr_reader :promotion
+  attr_accessor :base_code, :number_of_codes, :user
 
   validates :number_of_codes,
     numericality: { only_integer: true, greater_than: 0 },
@@ -13,16 +14,11 @@ class Spree::PromotionBuilder
   self.default_random_code_length = 6
 
   # @param promotion_attrs [Hash] The desired attributes for the newly promotion
-  # @param base_code [String] When number_of_codes=1 this is the code. When
-  #   number_of_codes > 1 it is the base of the generated codes.
-  # @param number_of_codes [Integer] Number of codes to generate
+  # @param attributes [Hash] The desired attributes for this builder
   # @param user [Spree::User] The user who triggered this promotion build
-  def initialize(promotion_attrs:, base_code:, number_of_codes:, user: nil)
-    @promotion_attrs = promotion_attrs
-    @promotion = Spree::Promotion.new(@promotion_attrs)
-    @base_code = base_code
-    @number_of_codes = number_of_codes
-    @user = user
+  def initialize(promotion_attrs, attributes)
+    @promotion = Spree::Promotion.new(promotion_attrs)
+    super(attributes)
   end
 
   def perform

--- a/core/app/models/spree/promotion_builder.rb
+++ b/core/app/models/spree/promotion_builder.rb
@@ -29,12 +29,8 @@ class Spree::PromotionBuilder
   # Build promo codes. If @number_of_codes is greater than one then generate
   # multiple codes by adding a random suffix to each code.
   def build_promotion_codes
-    if number_of_codes == 1
-      @promotion.codes.build(value: @base_code)
-    elsif number_of_codes > 1
-      @number_of_codes.times do
-        build_code_with_base
-      end
+    codes.each do |code|
+      @promotion.codes.build(value: code)
     end
   end
 
@@ -43,13 +39,19 @@ class Spree::PromotionBuilder
   end
 
   private
-  def build_code_with_base
-    random_code = code_with_randomness
 
-    if Spree::PromotionCode.where(value: random_code).exists? || @promotion.codes.any? {|c| c.value == random_code }
-      build_code_with_base
+  def codes
+    if number_of_codes == 1
+      [base_code]
     else
-      @promotion.codes.build(value: random_code)
+      random_codes
+    end
+  end
+
+  def random_codes
+    loop do 
+      code_list = number_of_codes.times.map { code_with_randomness }
+      return code_list if Spree::PromotionCode.where(value: code_list).empty?
     end
   end
 

--- a/core/app/models/spree/promotion_builder.rb
+++ b/core/app/models/spree/promotion_builder.rb
@@ -26,6 +26,12 @@ class Spree::PromotionBuilder
     @promotion.save
   end
 
+  def number_of_codes=value
+    @number_of_codes = value.presence.try(:to_i)
+  end
+
+  private
+
   # Build promo codes. If @number_of_codes is greater than one then generate
   # multiple codes by adding a random suffix to each code.
   def build_promotion_codes
@@ -33,12 +39,6 @@ class Spree::PromotionBuilder
       @promotion.codes.build(value: code)
     end
   end
-
-  def number_of_codes=value
-    @number_of_codes = value.presence.try(:to_i)
-  end
-
-  private
 
   def codes
     if number_of_codes == 1
@@ -51,12 +51,14 @@ class Spree::PromotionBuilder
   def random_codes
     loop do 
       code_list = number_of_codes.times.map { code_with_randomness }
-      return code_list if Spree::PromotionCode.where(value: code_list).empty?
+      if code_list.length == code_list.uniq.length && Spree::PromotionCode.where(value: code_list).empty?
+        return code_list
+      end
     end
   end
 
   def code_with_randomness
-    "#{@base_code}_#{Array.new(Spree::PromotionBuilder.default_random_code_length){ ('A'..'Z').to_a.sample }.join}"
+    "#{@base_code}_#{Array.new(Spree::PromotionBuilder.default_random_code_length){ ('a'..'z').to_a.sample }.join}"
   end
 
   def promotion_validity

--- a/core/app/models/spree/promotion_builder.rb
+++ b/core/app/models/spree/promotion_builder.rb
@@ -42,14 +42,6 @@ class Spree::PromotionBuilder
     end
   end
 
-  def error_messages
-    promotion.errors.full_messages.join(", ")
-  end
-
-  def success_messages
-    Spree.t(:successfully_created, resource: promotion.class.model_name.human)
-  end
-
   def number_of_codes=value
     @number_of_codes = value.presence.try(:to_i)
   end

--- a/core/app/models/spree/promotion_builder.rb
+++ b/core/app/models/spree/promotion_builder.rb
@@ -22,6 +22,8 @@ class Spree::PromotionBuilder
   end
 
   def perform
+    return false unless valid?
+
     build_promotion_codes if @base_code && @number_of_codes
     @promotion.save
   end

--- a/core/app/models/spree/promotion_builder.rb
+++ b/core/app/models/spree/promotion_builder.rb
@@ -16,8 +16,8 @@ class Spree::PromotionBuilder
   # @param promotion_attrs [Hash] The desired attributes for the newly promotion
   # @param attributes [Hash] The desired attributes for this builder
   # @param user [Spree::User] The user who triggered this promotion build
-  def initialize(promotion_attrs, attributes)
-    @promotion = Spree::Promotion.new(promotion_attrs)
+  def initialize(attributes={}, promotion_attributes={})
+    @promotion = Spree::Promotion.new(promotion_attributes)
     super(attributes)
   end
 

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -43,5 +43,4 @@ class Spree::PromotionCode < ActiveRecord::Base
   def adjustment_promotion_scope(adjustment_scope)
     adjustment_scope.promotion.where(source_id: promotion.actions.map(&:id), promotion_code_id: id)
   end
-
 end

--- a/core/app/models/spree/promotion_code/code_builder.rb
+++ b/core/app/models/spree/promotion_code/code_builder.rb
@@ -1,0 +1,60 @@
+# A class responsible for building PromotionCodes
+class ::Spree::PromotionCode::CodeBuilder
+  attr_reader :promotion, :num_codes, :base_code
+
+  class_attribute :random_code_length
+  self.random_code_length = 6
+
+  # Requres a +promotion+, +base_code+ and +num_codes+
+  #
+  # +promotion+ Must be a Spree::Promotion.
+  # +base_code+ Must be a String.
+  # +num_codes+ Must be a positive integer greater than zero.
+  def initialize promotion, base_code, num_codes
+    @base_code = base_code
+    @num_codes = num_codes
+    @promotion = promotion
+  end
+
+  # Builds and returns an array of Spree::PromotionCode's
+  def build_promotion_codes
+    codes.map do |code|
+      promotion.codes.build(value: code)
+    end
+  end
+
+  private
+
+  def codes
+    if num_codes > 1
+      generate_random_codes
+    else
+      [base_code]
+    end
+  end
+
+  def generate_random_codes
+    loop do
+      code_list = num_codes.times.map { generate_random_code }
+
+      return code_list if code_list_unique?(code_list)
+    end
+  end
+
+  def generate_random_code
+    suffix = Array.new(self.class.random_code_length) do
+      sample_characters.sample
+    end.join
+
+    "#{@base_code}_#{suffix}"
+  end
+
+  def sample_characters
+    @sample_characters ||= ('a'..'z').to_a
+  end
+
+  def code_list_unique? code_list
+    code_list.length == code_list.uniq.length &&
+      Spree::PromotionCode.where(value: code_list).empty?
+  end
+end

--- a/core/spec/models/spree/promotion_builder_spec.rb
+++ b/core/spec/models/spree/promotion_builder_spec.rb
@@ -72,6 +72,14 @@ describe Spree::PromotionBuilder do
   describe "#perform" do
     subject { builder.perform }
 
+    context 'builder is invalid' do
+      let(:number_of_codes) { 'sups' }
+
+      it 'returns false' do
+        expect(subject).to_not be
+      end
+    end
+
     context "with 1 or more codes" do
       it "builds promotion codes" do
         subject

--- a/core/spec/models/spree/promotion_builder_spec.rb
+++ b/core/spec/models/spree/promotion_builder_spec.rb
@@ -6,11 +6,11 @@ describe Spree::PromotionBuilder do
   let(:number_of_codes) { 1 }
   let(:promotion_attrs) { { name: 'some promo' } }
   let(:builder) { Spree::PromotionBuilder.new(
-    promotion_attrs,
     {
       base_code: base_code,
       number_of_codes: number_of_codes
-    }
+    },
+    promotion_attrs,
   ) }
 
   describe '#initialize' do

--- a/core/spec/models/spree/promotion_builder_spec.rb
+++ b/core/spec/models/spree/promotion_builder_spec.rb
@@ -7,6 +7,53 @@ describe Spree::PromotionBuilder do
   let(:promotion_attrs) { { name: 'some promo' } }
   let(:builder) { Spree::PromotionBuilder.new(promotion_attrs: promotion_attrs, base_code: base_code, number_of_codes: number_of_codes) }
 
+
+  describe '#valid?' do
+    subject {  builder.valid? }
+
+    it 'is true' do
+      expect(subject).to be
+    end
+
+    context 'promotion is not valid' do
+      let(:promotion_attrs) { { name: nil } }
+
+      it 'is true' do
+        expect(subject).to_not be
+      end
+
+      it 'has errors on the promotion' do
+        subject
+        expect(builder.errors).to_not be_empty
+      end
+    end
+
+    context 'number of codes is invalid' do
+      let(:number_of_codes) { -1 }
+
+      it 'is false ' do
+        expect(subject).to_not be
+      end
+
+      it 'validates numericality' do
+        subject
+        expect(builder.errors.full_messages).to eq ["Number of codes must be greater than 0"]
+      end
+    end
+  end
+
+  describe '#number_of_codes=' do
+    it 'coerces a string' do
+      builder.number_of_codes = '3'
+      expect(builder.number_of_codes).to eq 3
+    end
+
+    it 'is nil for empty string' do
+      builder.number_of_codes = ''
+      expect(builder.number_of_codes).to be_nil
+    end
+  end
+
   describe "#perform" do
     subject { builder.perform }
 

--- a/core/spec/models/spree/promotion_builder_spec.rb
+++ b/core/spec/models/spree/promotion_builder_spec.rb
@@ -5,9 +5,24 @@ describe Spree::PromotionBuilder do
   let(:base_code) { 'abc' }
   let(:number_of_codes) { 1 }
   let(:promotion_attrs) { { name: 'some promo' } }
-  let(:builder) { Spree::PromotionBuilder.new(promotion_attrs: promotion_attrs, base_code: base_code, number_of_codes: number_of_codes) }
+  let(:builder) { Spree::PromotionBuilder.new(
+    promotion_attrs,
+    {
+      base_code: base_code,
+      number_of_codes: number_of_codes
+    }
+  ) }
 
+  describe '#initialize' do
+    subject { builder }
+    it 'has the right base code' do
+      expect(subject.base_code).to eq 'abc'
+    end
 
+    it 'has the right base code' do
+      expect(subject.number_of_codes).to eq 1
+    end
+  end
   describe '#valid?' do
     subject {  builder.valid? }
 

--- a/core/spec/models/spree/promotion_builder_spec.rb
+++ b/core/spec/models/spree/promotion_builder_spec.rb
@@ -133,22 +133,4 @@ describe Spree::PromotionBuilder do
     end
   end
 
-  describe "#error_messages" do
-    let(:promotion_attrs) { {} }
-    subject { builder.error_messages }
-    before { builder.perform }
-
-    it "returns the promotion's errors" do
-      expect(subject).to eq "Name can't be blank"
-    end
-  end
-
-  describe "#success_messages" do
-    subject { builder.success_messages }
-    before { builder.perform }
-
-    it "returns 'Promotion has been successfully created!'" do
-      expect(subject).to eq "Promotion has been successfully created!"
-    end
-  end
 end

--- a/core/spec/models/spree/promotion_code/code_builder_spec.rb
+++ b/core/spec/models/spree/promotion_code/code_builder_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe Spree::PromotionCode::CodeBuilder do
+  let(:promotion) { build_stubbed :promotion }
+  let(:base_code) { "abc" }
+  let(:builder) do
+    described_class.new promotion, base_code, num_codes
+  end
+
+  describe "#build_promotion_codes" do
+    subject { builder.build_promotion_codes }
+
+    context "with one code" do
+      let(:num_codes) { 1 }
+
+      it "builds a single promotion code" do
+        subject
+        expect(builder.promotion.codes).to have(num_codes).items
+      end
+
+      it "creates the promotion code with the correct value" do
+        subject
+        expect(builder.promotion.codes.first.value).to eq base_code
+      end
+    end
+
+    context "with more than one code" do
+      before { srand 123 }
+      let(:num_codes) { 2 }
+
+      it "builds the correct number of codes" do
+        subject
+        expect(builder.promotion.codes).to have(num_codes).items
+      end
+
+      it "builds codes with distinct values" do
+        subject
+        expect(builder.promotion.codes.map(&:value).uniq).to have(num_codes).items
+      end
+
+      it "builds codes with the same base prefix" do
+        subject
+        values = builder.promotion.codes.map &:value
+        expect(values.all? { |val| val.starts_with?("#{base_code}_") }).to be true
+      end
+
+      context 'when there is a code colision' do
+        before do
+          @old_length = described_class.random_code_length
+          described_class.random_code_length = 1
+        end
+        after { described_class.random_code_length = @old_length }
+
+        let(:number_of_codes) { 26 }
+
+        # With a random code length of 1, collisions happen frequently.
+        # with srand(123) it happens after the second iteration.
+        it "resolves the collision" do
+          subject
+          expect(builder.promotion.codes.map(&:value).uniq).to have(num_codes).items
+        end
+      end
+
+    end
+  end
+
+end


### PR DESCRIPTION
Switches the service object to use ActiveModel

Should stabilize the API in the future and make it easier to extend/translate/validate etc.