### PR TITLE
Make sure to touch variants when stock is adjusted below zero.

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -69,7 +69,7 @@ module Spree
 
       def conditional_variant_touch
         # the variant_id changes from nil when a new stock location is added
-        stock_changed = (count_on_hand_changed? && count_on_hand_change.any?(&:zero?)) || variant_id_changed?
+        stock_changed = (count_on_hand_changed? && count_on_hand_change.any? { |c| c < 1 }) || variant_id_changed?
 
         if !Spree::Config.binary_inventory_cache || stock_changed
           variant.touch

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -155,39 +155,55 @@ describe Spree::StockItem do
       subject.variant.update_column(:updated_at, 1.day.ago)
     end
 
+    before do
+      Spree::Config.binary_inventory_cache = binary_inventory_cache
+    end
+
     context "binary_inventory_cache is set to false (default)" do
+      let(:binary_inventory_cache) { false }
+
       context "in_stock? changes" do
         it "touches its variant" do
           expect do
-            subject.adjust_count_on_hand(subject.count_on_hand * -1)
-          end.to change { subject.variant.reload.updated_at }
+            subject.set_count_on_hand(0)
+          end.to change { subject.variant.updated_at }
         end
       end
 
       context "in_stock? does not change" do
         it "touches its variant" do
           expect do
-            subject.adjust_count_on_hand((subject.count_on_hand * -1) + 1)
-          end.to change { subject.variant.reload.updated_at }
+            subject.set_count_on_hand(-1)
+          end.to change { subject.variant.updated_at }
         end
       end
     end
 
     context "binary_inventory_cache is set to true" do
-      before { Spree::Config.binary_inventory_cache = true }
+      let(:binary_inventory_cache) { true }
+
       context "in_stock? changes" do
         it "touches its variant" do
           expect do
-            subject.adjust_count_on_hand(subject.count_on_hand * -1)
-          end.to change { subject.variant.reload.updated_at }
+            subject.set_count_on_hand(0)
+          end.to change { subject.variant.updated_at }
+        end
+
+        # Regression spec
+        context "stock changes to below zero" do
+          it "touches its variant" do
+            expect do
+              subject.set_count_on_hand(-1)
+            end.to change { subject.variant.updated_at }
+          end
         end
       end
 
       context "in_stock? does not change" do
         it "does not touch its variant" do
           expect do
-            subject.adjust_count_on_hand((subject.count_on_hand * -1) + 1)
-          end.not_to change { subject.variant.reload.updated_at }
+            subject.set_count_on_hand(1)
+          end.not_to change { subject.reload.variant.updated_at }
         end
       end
 


### PR DESCRIPTION
Stock can be adjusted below zero in some odd scenarios, and when binary
inventory cache is turned on we want to make sure to still touch the
variant in those scenarios.