### PR TITLE
Fix the option types field on edit product

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js.erb
@@ -6,11 +6,13 @@ $(document).ready(function () {
       placeholder: Spree.translations.option_type_placeholder,
       multiple: true,
       initSelection: function (element, callback) {
-        var url = Spree.url(Spree.routes.option_type_search, {
-          ids: element.val()
-        });
-        return Spree.getJSON(url, null, function (data) {
-          return callback(data);
+        return Spree.ajax({
+          url: Spree.routes.option_type_search,
+          data: { ids: element.val() },
+          type: 'get',
+          success: function(data) {
+            return callback(data);
+          }
         });
       },
       ajax: {


### PR DESCRIPTION
In the admin, when editing a product, the option types currently don't
display correctly. That is because we use the deprecated `Spree.url` in
the AJAX request to load the initial data for the select2.

This switches to using `Spree.ajax`, which works correctly.