### PR TITLE
Sign in the current API user when authenticating from Token

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -56,6 +56,7 @@ module Spree
 
       def load_user
         @current_api_user ||= Spree.user_class.find_by(spree_api_key: api_key.to_s)
+        sign_in @current_api_user, store: false if @current_api_user
       end
 
       def authenticate_user


### PR DESCRIPTION
Currently, when authenticating from token, we have to use
`@current_api_user`. This will allow any code that relies on
`spree_current_user` or `try_spree_current_user` to continue to work
correctly. As we use `store: false`, this will only apply to the current
request and not attempt to store the auth in the session.

cc @richardnuno