### PR TITLE
Fix promo code generation bug

### DIFF
--- a/core/app/models/spree/promotion_code/code_builder.rb
+++ b/core/app/models/spree/promotion_code/code_builder.rb
@@ -41,7 +41,7 @@ class ::Spree::PromotionCode::CodeBuilder
       valid_codes += get_unique_codes(new_codes)
     end
 
-    valid_codes.to_a
+    valid_codes.to_a.take(num_codes)
   end
 
   def generate_random_code


### PR DESCRIPTION
With the old code, collisions could cause more codes to be generated than were
intended. This fixes that.  We could've alternatively done
`(num_codes - valid_codes.size).times` instead, but that performs much
worse with a large number of codes and lots of collisions.

I feel like we still don't have the best collision resolution strategy in
general here but this at least fixes a definite bug.