### PR TITLE
Allow admin association of users to stock locations.

### DIFF
--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -1,13 +1,13 @@
 module Spree
   module Admin
     class UsersController < ResourceController
-      rescue_from Spree::Core::DestroyWithOrdersError, :with => :user_destroy_with_orders_error
+      rescue_from Spree::Core::DestroyWithOrdersError, with: :user_destroy_with_orders_error
 
-      after_filter :sign_in_if_change_own_password, :only => :update
+      after_filter :sign_in_if_change_own_password, only: :update
 
       # http://spreecommerce.com/blog/2010/11/02/json-hijacking-vulnerability/
-      before_filter :check_json_authenticity, :only => :index
-      before_filter :load_roles
+      before_filter :check_json_authenticity, only: :index
+      before_filter :load_roles, :load_stock_locations, only: [:edit, :new]
 
       def index
         respond_with(@collection) do |format|
@@ -21,37 +21,26 @@ module Spree
       end
 
       def create
-        if params[:user]
-          roles = params[:user].delete("spree_role_ids")
-        end
-
         @user = Spree.user_class.new(user_params)
         if @user.save
+          set_roles
+          set_stock_locations
 
-          if roles
-            @user.spree_roles = roles.reject(&:blank?).collect{|r| Spree::Role.find(r)}
-          end
-
-          flash.now[:success] = Spree.t(:created_successfully)
-          render :edit
+          flash[:success] = Spree.t(:created_successfully)
+          redirect_to edit_admin_user_url(@user)
         else
-          render :new
+          redirect_to new_admin_user_url
         end
       end
 
       def update
-        if params[:user]
-          roles = params[:user].delete("spree_role_ids")
-        end
-
         if @user.update_attributes(user_params)
-          if roles
-            @user.spree_roles = roles.reject(&:blank?).collect{|r| Spree::Role.find(r)}
-          end
-          flash.now[:success] = Spree.t(:account_updated)
+          set_roles
+          set_stock_locations
+          flash[:success] = Spree.t(:account_updated)
         end
 
-        render :edit
+        redirect_to edit_admin_user_url(@user)
       end
 
       def addresses
@@ -153,6 +142,18 @@ module Spree
 
         def load_roles
           @roles = Spree::Role.all
+        end
+
+        def load_stock_locations
+          @stock_locations = Spree::StockLocation.all
+        end
+
+        def set_roles
+          @user.spree_roles = Spree::Role.where(id: (params[:user][:spree_role_ids] || []))
+        end
+
+        def set_stock_locations
+          @user.stock_locations = Spree::StockLocation.where(id: (params[:user][:stock_location_ids] || []))
         end
     end
   end

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -16,7 +16,18 @@
           </li>
         <% end %>
       </ul>
-      <%= hidden_field_tag 'user[spree_role_ids][]', '' %>
+    </div>
+
+    <div data-hook="admin_user_form_stock_locations" class="field">
+      <%= label_tag nil, Spree.t(:stock_locations) %>
+      <ul>
+        <% @stock_locations.each do |stock_location| %>
+          <li>
+            <%= check_box_tag 'user[stock_location_ids][]', stock_location.id, @user.stock_locations.include?(stock_location), :id => "user_spree_stock_locations_#{stock_location.name}" %>
+            <%= label_tag stock_location.name %>
+          </li>
+        <% end %>
+      </ul>
     </div>
 
   </div>

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -68,6 +68,7 @@ describe Spree::Admin::UsersController do
   describe "#create" do
     before do
       use_mock_user
+      allow(mock_user).to receive_messages(:spree_roles= => true, :stock_locations= => true)
       user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
     end
 
@@ -84,11 +85,26 @@ describe Spree::Admin::UsersController do
       ))
       spree_post :create, { :user => { :bill_address_attributes => { :city => "New York" } } }
     end
+
+    it "can set roles" do
+      role = Spree::Role.create(name: "my_role")
+      role_2 = Spree::Role.create(name: "my_role_2")
+      expect(mock_user).to receive(:spree_roles=).with([role, role_2])
+      spree_post :create, { user: { spree_role_ids: [role.id, role_2.id] } }
+    end
+
+    it "can set stock locations" do
+      location = Spree::StockLocation.create(name: "my_location")
+      location_2 = Spree::StockLocation.create(name: "my_location_2")
+      expect(mock_user).to receive(:stock_locations=).with([location, location_2])
+      spree_post :create, { user: { stock_location_ids: [location.id, location_2.id] } }
+    end
   end
 
   describe "#update" do
     before do
       use_mock_user
+      allow(mock_user).to receive_messages(:spree_roles= => true, :stock_locations= => true)
       user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
     end
 
@@ -104,6 +120,20 @@ describe Spree::Admin::UsersController do
         "bill_address_attributes" => { "city" => "New York" }
       ))
       spree_put :update, { :id => mock_user.id, :user => { :bill_address_attributes => { :city => "New York" } } }
+    end
+
+    it "can set roles" do
+      role = Spree::Role.create(name: "my_role")
+      role_2 = Spree::Role.create(name: "my_role_2")
+      expect(mock_user).to receive(:spree_roles=).with([role, role_2])
+      spree_put :update, { id: mock_user.id, user: { spree_role_ids: [role.id, role_2.id] } }
+    end
+
+    it "can set stock locations" do
+      location = Spree::StockLocation.create(name: "my_location")
+      location_2 = Spree::StockLocation.create(name: "my_location_2")
+      expect(mock_user).to receive(:stock_locations=).with([location, location_2])
+      spree_put :update, { id: mock_user.id, user: { stock_location_ids: [location.id, location_2.id] } }
     end
   end
 
@@ -150,6 +180,7 @@ end
 
 def use_mock_user
   mock_user.stub(:save).and_return(true)
+  mock_user.stub(:update_attributes).and_return(true)
   Spree.user_class.stub(:find).with(mock_user.id.to_s).and_return(mock_user)
   Spree.user_class.stub(:new).and_return(mock_user)
 end

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -4,6 +4,8 @@ module Spree
     has_many :cartons, inverse_of: :stock_location
     has_many :stock_items, dependent: :delete_all
     has_many :stock_movements, through: :stock_items
+    has_many :user_stock_locations, dependent: :delete_all
+    has_many :users, through: :user_stock_locations
 
     belongs_to :state, class_name: 'Spree::State'
     belongs_to :country, class_name: 'Spree::Country'

--- a/core/app/models/spree/user_stock_location.rb
+++ b/core/app/models/spree/user_stock_location.rb
@@ -1,0 +1,6 @@
+module Spree
+  class UserStockLocation < ActiveRecord::Base
+    belongs_to :user, class_name: Spree.user_class.to_s, inverse_of: :user_stock_locations
+    belongs_to :stock_location, class_name: "Spree::StockLocation", inverse_of: :user_stock_locations
+  end
+end

--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -7,6 +7,9 @@ Spree::Core::Engine.config.to_prepare do
       has_many :role_users, foreign_key: "user_id", class_name: "Spree::RoleUser"
       has_many :spree_roles, through: :role_users, source: :role
 
+      has_many :user_stock_locations, foreign_key: "user_id", class_name: "Spree::UserStockLocation"
+      has_many :stock_locations, through: :user_stock_locations
+
       has_many :spree_orders, :foreign_key => "user_id", :class_name => "Spree::Order"
 
       belongs_to :ship_address, :class_name => 'Spree::Address'

--- a/core/db/migrate/20150330144639_create_spree_user_stock_locations.rb
+++ b/core/db/migrate/20150330144639_create_spree_user_stock_locations.rb
@@ -1,0 +1,10 @@
+class CreateSpreeUserStockLocations < ActiveRecord::Migration
+  def change
+    create_table :spree_user_stock_locations do |t|
+      t.integer :user_id
+      t.integer :stock_location_id
+      t.timestamps
+    end
+    add_index :spree_user_stock_locations, :user_id
+  end
+end


### PR DESCRIPTION
In the case where you have people working in physical stock locations,
you want to be able to restrict which stock locations those people have
the ability to fulfill out of. E.g. you wouldn't want the worker in your
New York store to create admin orders to fulfill out of your California
store. Adding a many-many association between users and stock
locations enables the ability to restrict which stock locations a user
has the access to do anything in.

This step just adds the association and administration, the restriction
based off of this association will come in another set of work.