### PR TITLE
Add code field to stock locations

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -5,6 +5,10 @@
         <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
         <%= f.text_field :name, :class => 'fullwidth' %>
       <% end %><br>
+      <%= f.field_container :code do %>
+        <%= f.label :code, Spree.t(:code) %>
+        <%= f.text_field :code, :class => 'fullwidth', :label => false %>
+      <% end %><br>
       <%= f.field_container :admin_name do %>
         <%= f.label :admin_name, Spree.t(:internal_name) %>
         <%= f.text_field :admin_name, :class => 'fullwidth', :label => false %>

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -9,6 +9,7 @@ module Spree
     belongs_to :country, class_name: 'Spree::Country'
 
     validates_presence_of :name
+    validates_uniqueness_of :code, allow_blank: true, case_sensitive: false
 
     scope :active, -> { where(active: true) }
     scope :order_default, -> { order(default: :desc, name: :asc) }

--- a/core/db/migrate/20150331134544_add_stock_location_code.rb
+++ b/core/db/migrate/20150331134544_add_stock_location_code.rb
@@ -1,0 +1,5 @@
+class AddStockLocationCode < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_locations, :code, :string
+  end
+end


### PR DESCRIPTION
The code field is a new column that is meant to be used as a unique text identifier. This can be helpful when trying to determine stock locations in integrations. The new column was added because both name and admin_name are used for display purposes.