### PR TITLE
Add originator to stock movements made in admin

### DIFF
--- a/backend/app/controllers/spree/admin/stock_items_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_items_controller.rb
@@ -13,7 +13,7 @@ module Spree
       def create
         variant = Variant.find(params[:variant_id])
         stock_location = StockLocation.find(params[:stock_location_id])
-        stock_movement = stock_location.stock_movements.build(stock_movement_params)
+        stock_movement = stock_location.stock_movements.build(stock_movement_params.merge(originator: try_spree_current_user))
         stock_movement.stock_item = stock_location.set_up_stock_item(variant)
 
         if stock_movement.save

--- a/backend/spec/controllers/spree/admin/stock_items_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_items_controller_spec.rb
@@ -14,6 +14,24 @@ module Spree
           }.to change{ StockItem.count }.by(-1)
         end
       end
+
+      context "create" do
+        let!(:variant) { create(:variant) }
+        let!(:stock_location) { variant.stock_locations.first }
+        let(:stock_item) { variant.stock_items.first }
+
+        before { request.env["HTTP_REFERER"] = "product_admin_page" }
+
+        subject do
+          spree_post :create, { variant_id: variant, stock_location_id: stock_location, stock_movement: { quantity: 1, stock_item_id: stock_item.id } }
+        end
+
+        it "creates a stock movement with originator" do
+          expect { subject }.to change { Spree::StockMovement.count }.by(1)
+          stock_movement = Spree::StockMovement.last
+          expect(stock_movement.originator_type).to eq "Spree::LegacyUser"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Stock movements made in product/stock path will default the originator
to nil. This change sets the originator to the current user to
indicate that an admin is making the movement.