### PR TITLE
Carton Admin

### DIFF
--- a/backend/app/views/spree/admin/orders/_carton.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton.html.erb
@@ -1,0 +1,73 @@
+<div id="<%= dom_id(carton) %>" data-hook="admin_carton_form">
+  <%= render :partial => "spree/admin/variants/split", :formats => :js %>
+  <fieldset class="no-border-bottom">
+    <legend align="center" class="stock-location" data-hook="stock-location">
+      <span class="carton-number"><%= carton.number %></span>
+      -
+      <span class="carton-state"><%= Spree.t("shipment_states.shipped") %></span>
+      <%= Spree.t(:package_from) %>
+      <strong class="stock-location-name" data-hook="stock-location-name">'<%= carton.stock_location.name %>'</strong>
+    </legend>
+  </fieldset>
+
+  <table class="stock-contents index" data-hook="stock-contents">
+    <colgroup>
+      <col style="width: 10%;" />
+      <col style="width: 55%;" />
+      <col style="width: 15%;" />
+      <col style="width: 5%;" />
+      <col style="width: 15%;" />
+    </colgroup>
+
+    <thead>
+      <th colspan="2"><%= Spree.t(:item_description) %></th>
+      <th><%= Spree.t(:price) %></th>
+      <th><%= Spree.t(:quantity) %></th>
+      <th><%= Spree.t(:total) %></th>
+    </thead>
+
+    <tbody data-shipment-number="<%= carton.number %>" data-order-number="<%= order.number %>">
+      <%= render 'spree/admin/orders/carton_manifest', carton: carton %>
+
+      <tr class="show-method total">
+        <% if method = carton.shipping_method %>
+          <td colspan="5">
+            <strong><%= method.name %></strong>
+          </td>
+        <% else %>
+          <td colspan='5'><%= Spree.t(:no_shipping_method_selected) %></td>
+        <% end %>
+      </tr>
+
+      <% if order.special_instructions.present? %>
+        <tr class='special_instructions'>
+          <td colspan="5">
+            <strong><%= Spree.t(:special_instructions) %>:&nbsp;</strong><%= order.special_instructions %>
+          </td>
+        </tr>
+      <% end %>
+
+      <tr class="show-tracking total">
+        <td colspan="5">
+          <% if carton.tracking.present? %>
+            <strong><%= Spree.t(:tracking) %>:</strong> <%= carton.tracking %>
+          <% else %>
+            <%= Spree.t(:no_tracking_present) %>
+          <% end %>
+        </td>
+      </tr>
+
+      <tr class='shipment-numbers'>
+        <td colspan="5">
+          <strong><%= Spree.t(:shipment_numbers) %>:&nbsp;</strong><%= carton.shipment_numbers.join(", ") %>
+        </td>
+      </tr>
+
+      <tr class='ship-date'>
+        <td colspan="5">
+          <strong><%= Spree.t(:shipment_date) %>:&nbsp;</strong><%= carton.display_shipped_at %>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
@@ -1,0 +1,23 @@
+<% carton.manifest.each do |item| %>
+  <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
+    <td class="item-image">
+      <%= mini_image(item.variant) %>
+    </td>
+    <td class="item-name">
+      <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
+      <% if item.variant.sku.present? %>
+        <strong><%= Spree.t(:sku) %>:</strong> <%= item.variant.sku %>
+      <% end %>
+    </td>
+    <td class="item-price align-center"><%= item.line_item.single_money.to_html %></td>
+    <td class="item-qty-show align-center">
+        <% item.states.each do |state,count| %>
+          <%= count %>
+        <% end %>
+    </td>
+    <td class="item-qty-edit hidden">
+      <%= number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5 %>
+    </td>
+    <td class="item-total align-center"><%= line_item_shipment_price(item.line_item, item.quantity) %></td>
+  </tr>
+<% end %>

--- a/backend/app/views/spree/admin/orders/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_form.html.erb
@@ -4,6 +4,7 @@
   <% end %>
 
   <% if Spree::Order.checkout_step_names.include?(:delivery) %>
+    <%= render :partial => "spree/admin/orders/carton", :collection => @order.cartons.order(:created_at), :locals => { :order => order } %>
     <%= render :partial => "spree/admin/orders/shipment", :collection => @order.shipments.order(:created_at), :locals => { :order => order } %>
   <% else %>
     <%= render :partial => "spree/admin/orders/line_items", :locals => { :order => order } %>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -1,115 +1,118 @@
-<div id="<%= "shipment_#{shipment.id}" %>" data-hook="admin_shipment_form">
-  <%= render :partial => "spree/admin/variants/split", :formats => :js %>
-  <fieldset class="no-border-bottom">
-    <legend align="center" class="stock-location" data-hook="stock-location">
-      <span class="shipment-number"><%= shipment.number %></span>
-      -
-      <span class="shipment-state"><%= Spree.t("shipment_states.#{shipment.state}") %></span>
-      <%= Spree.t(:package_from) %>
-      <strong class="stock-location-name" data-hook="stock-location-name">'<%= shipment.stock_location.name %>'</strong>
-      <% if shipment.ready? && can?(:update, shipment) %>
-        <%= (' - ' + link_to(Spree.t(:ship), '#', :class => 'ship button fa fa-arrow-right', :data => {'shipment-number' => shipment.number})).html_safe %>
-      <% end %>
-    </legend>
-  </fieldset>
+<% manifest_items = Spree::ShippingManifest.new(inventory_units: shipment.inventory_units.where(carton_id: nil)).items %>
 
-  <table class="stock-contents index" data-hook="stock-contents">
-    <colgroup>
-      <col style="width: 10%;" />
-      <col style="width: 30%;" />
-      <col style="width: 15%;" />
-      <col style="width: 15%;" />
-      <col style="width: 15%;" />
-      <col style="width: 15%;" />
-    </colgroup>
+<% unless manifest_items.empty? %>
+  <div id="<%= "shipment_#{shipment.id}" %>" data-hook="admin_shipment_form">
+    <%= render :partial => "spree/admin/variants/split", :formats => :js %>
+    <fieldset class="no-border-bottom">
+      <legend align="center" class="stock-location" data-hook="stock-location">
+        <span class="shipment-number"><%= shipment.number %></span>
+        -
+        <span class="shipment-state"><%= Spree.t("shipment_states.#{shipment.state}") %></span>
+        <%= Spree.t(:package_from) %>
+        <strong class="stock-location-name" data-hook="stock-location-name">'<%= shipment.stock_location.name %>'</strong>
+        <% if shipment.ready? && can?(:update, shipment) %>
+          <%= (' - ' + link_to(Spree.t(:ship), '#', :class => 'ship button fa fa-arrow-right', :data => {'shipment-number' => shipment.number})).html_safe %>
+        <% end %>
+      </legend>
+    </fieldset>
 
-    <thead>
-      <th colspan="2"><%= Spree.t(:item_description) %></th>
-      <th><%= Spree.t(:price) %></th>
-      <th><%= Spree.t(:quantity) %></th>
-      <th><%= Spree.t(:total) %></th>
-      <th class="orders-actions actions" data-hook="admin_order_form_line_items_header_actions"></th>
-    </thead>
+    <table class="stock-contents index" data-hook="stock-contents">
+      <colgroup>
+        <col style="width: 10%;" />
+        <col style="width: 30%;" />
+        <col style="width: 15%;" />
+        <col style="width: 15%;" />
+        <col style="width: 15%;" />
+        <col style="width: 15%;" />
+      </colgroup>
 
-    <tbody data-shipment-number="<%= shipment.number %>" data-order-number="<%= order.number %>">
-      <%= render 'spree/admin/orders/shipment_manifest', shipment: shipment %>
+      <thead>
+        <th colspan="2"><%= Spree.t(:item_description) %></th>
+        <th><%= Spree.t(:price) %></th>
+        <th><%= Spree.t(:quantity) %></th>
+        <th><%= Spree.t(:total) %></th>
+        <th class="orders-actions actions" data-hook="admin_order_form_line_items_header_actions"></th>
+      </thead>
 
-      <% unless shipment.shipped? %>
-        <tr class="edit-method hidden total">
+      <tbody data-shipment-number="<%= shipment.number %>" data-order-number="<%= order.number %>">
+        <%= render 'spree/admin/orders/shipment_manifest', { shipment_number: shipment.number, shipment_manifest: manifest_items } %>
+
+        <% unless shipment.shipped? %>
+          <tr class="edit-method hidden total">
+            <td colspan="5">
+              <div class="field alpha five columns">
+                <%= label_tag 'selected_shipping_rate_id', Spree.t(:shipping_method) %>
+                <%= select_tag :selected_shipping_rate_id,
+                      options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
+                      {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>
+              </div>
+            </td>
+            <td class="actions">
+              <% if can? :update, shipment %>
+                <%= link_to '', '#', :class => 'save-method fa fa-check no-text with-tip',
+                  :data => {'shipment-number' => shipment.number, :action => 'save'}, title: Spree.t('actions.save') %>
+                <%= link_to '', '#', :class => 'cancel-method fa fa-cancel no-text with-tip',
+                  :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel') %>
+              <% end %>
+            </td>
+          </tr>
+          <% end %>
+
+          <tr class="show-method total">
+            <% if rate = shipment.selected_shipping_rate %>
+              <td colspan="4">
+                <strong><%= rate.name %></strong>
+              </td>
+              <td class="total" align="center">
+                <span><%= shipment.display_cost %></span>
+              </td>
+            <% else %>
+              <td colspan='5'><%= Spree.t(:no_shipping_method_selected) %></td>
+            <% end %>
+
+            <td class="actions">
+              <% if( (can? :update, shipment) and !shipment.shipped?) %>
+                <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
+              <% end %>
+            </td>
+          </tr>
+
+        <tr class="edit-tracking hidden total">
           <td colspan="5">
-            <div class="field alpha five columns">
-              <%= label_tag 'selected_shipping_rate_id', Spree.t(:shipping_method) %>
-              <%= select_tag :selected_shipping_rate_id,
-                    options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
-                    {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>
-            </div>
+            <label><%= Spree.t(:tracking_number) %>:</label>
+            <%= text_field_tag :tracking, shipment.tracking %>
           </td>
           <td class="actions">
             <% if can? :update, shipment %>
-              <%= link_to '', '#', :class => 'save-method fa fa-check no-text with-tip',
-                :data => {'shipment-number' => shipment.number, :action => 'save'}, title: Spree.t('actions.save') %>
-              <%= link_to '', '#', :class => 'cancel-method fa fa-cancel no-text with-tip',
-                :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel') %>
+              <%= link_to '', '#', :class => 'save-tracking fa fa-check no-text with-tip', :data => {'shipment-number' => shipment.number, :action => 'save'}, :title => Spree.t('actions.save') %>
+              <%= link_to '', '#', :class => 'cancel-tracking fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel') %>
             <% end %>
           </td>
         </tr>
+
+        <% if order.special_instructions.present? %>
+          <tr class='special_instructions'>
+            <td colspan="5">
+              <strong><%= Spree.t(:special_instructions) %>:&nbsp;</strong><%= order.special_instructions %>
+            </td>
+          </tr>
         <% end %>
 
-        <tr class="show-method total">
-          <% if rate = shipment.selected_shipping_rate %>
-            <td colspan="4">
-              <strong><%= rate.name %></strong>
-            </td>
-            <td class="total" align="center">
-              <span><%= shipment.display_cost %></span>
-            </td>
-          <% else %>
-            <td colspan='5'><%= Spree.t(:no_shipping_method_selected) %></td>
-          <% end %>
-
+        <tr class="show-tracking total">
+          <td colspan="5">
+            <% if shipment.tracking.present? %>
+              <strong><%= Spree.t(:tracking) %>:</strong> <%= shipment.tracking %>
+            <% else %>
+              <%= Spree.t(:no_tracking_present) %>
+            <% end %>
+          </td>
           <td class="actions">
-            <% if( (can? :update, shipment) and !shipment.shipped?) %>
-              <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
+            <% if can? :update, shipment %>
+              <%= link_to '', '#', :class => 'edit-tracking fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
             <% end %>
           </td>
         </tr>
-
-
-      <tr class="edit-tracking hidden total">
-        <td colspan="5">
-          <label><%= Spree.t(:tracking_number) %>:</label>
-          <%= text_field_tag :tracking, shipment.tracking %>
-        </td>
-        <td class="actions">
-          <% if can? :update, shipment %>
-            <%= link_to '', '#', :class => 'save-tracking fa fa-check no-text with-tip', :data => {'shipment-number' => shipment.number, :action => 'save'}, :title => Spree.t('actions.save') %>
-            <%= link_to '', '#', :class => 'cancel-tracking fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel') %>
-          <% end %>
-        </td>
-      </tr>
-
-      <% if order.special_instructions.present? %>
-        <tr class='special_instructions'>
-          <td colspan="5">
-            <strong><%= Spree.t(:special_instructions) %>:&nbsp;</strong><%= order.special_instructions %>
-          </td>
-        </tr>
-      <% end %>
-
-      <tr class="show-tracking total">
-        <td colspan="5">
-          <% if shipment.tracking.present? %>
-            <strong><%= Spree.t(:tracking) %>:</strong> <%= shipment.tracking %>
-          <% else %>
-            <%= Spree.t(:no_tracking_present) %>
-          <% end %>
-        </td>
-        <td class="actions">
-          <% if can? :update, shipment %>
-            <%= link_to '', '#', :class => 'edit-tracking fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
-          <% end %>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -1,4 +1,4 @@
-<% shipment.manifest.each do |item| %>
+<% shipment_manifest.each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
     <td class="item-image">
       <%= mini_image(item.variant) %>
@@ -15,23 +15,18 @@
           <%= count %> x <%= Spree.t(state).downcase %>
         <% end %>
     </td>
-    <% unless shipment.shipped? %>
-      <td class="item-qty-edit hidden">
-        <%= number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5 %>
-      </td>
-    <% end %>
+    <td class="item-qty-edit hidden">
+      <%= number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5 %>
+    </td>
     <td class="item-total align-center"><%= line_item_shipment_price(item.line_item, item.quantity) %></td>
-    <% unless shipment.shipped? %>
-      <td class="cart-item-delete actions" data-hook="cart_item_delete">
-        <% if can? :update, item %>
-          <%= link_to '', '#', :class => 'save-item fa fa-check no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'save'}, :title => Spree.t('actions.save'), :style => 'display: none' %>
-          <%= link_to '', '#', :class => 'cancel-item fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel'), :style => 'display: none' %>
-          <% if shipment.order.shipped_shipments.count == 0 %>
-            <%= link_to '', '#', :class => 'split-item icon_link fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => Spree.t('split') %>
-            <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => { 'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => Spree.t('delete') %>
-          <% end %>
-        <% end %>
-      </td>
-    <% end %>
+
+    <td class="cart-item-delete actions" data-hook="cart_item_delete">
+      <% if can? :update, item %>
+        <%= link_to '', '#', :class => 'save-item fa fa-check no-text with-tip', :data => {'shipment-number' => shipment_number, 'variant-id' => item.variant.id, :action => 'save'}, :title => Spree.t('actions.save'), :style => 'display: none' %>
+        <%= link_to '', '#', :class => 'cancel-item fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel'), :style => 'display: none' %>
+        <%= link_to '', '#', :class => 'split-item icon_link fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => Spree.t('split') %>
+        <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => { 'shipment-number' => shipment_number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => Spree.t('delete') %>
+      <% end %>
+    </td>
   </tr>
 <% end %>

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -57,7 +57,9 @@ describe "New Order" do
     click_on "ship"
     wait_for_ajax
 
-    page.should have_content("shipped")
+    within '.carton-state' do
+      page.should have_content('SHIPPED')
+    end
   end
 
   context "adding new item to the order", js: true do

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -509,18 +509,6 @@ describe "Order Details", js: true do
       page.should_not have_link('Return Authorizations')
     end
 
-    it "can add tracking information" do
-      visit spree.edit_admin_order_path(order)
-      within("table.index tr:nth-child(5)") do
-        click_icon :edit
-      end
-      fill_in "tracking", :with => "FOOBAR"
-      click_icon :check
-
-      page.should_not have_css("input[name=tracking]")
-      page.should have_content("Tracking: FOOBAR")
-    end
-
     it "can change the shipping method" do
       order = create(:completed_order_with_totals)
       visit spree.edit_admin_order_path(order)
@@ -538,9 +526,11 @@ describe "Order Details", js: true do
       order = create(:order_ready_to_ship)
       order.contents.refresh_shipment_rates
       visit spree.edit_admin_order_path(order)
+
       click_icon 'arrow-right'
       wait_for_ajax
-      within '.shipment-state' do
+
+      within '.carton-state' do
         page.should have_content('SHIPPED')
       end
     end

--- a/core/app/models/spree/carton.rb
+++ b/core/app/models/spree/carton.rb
@@ -1,12 +1,11 @@
 class Spree::Carton < ActiveRecord::Base
-  include Spree::ShippingManifest
-
   belongs_to :address, class_name: 'Spree::Address', inverse_of: :cartons
   belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :cartons
   belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :cartons
 
   has_many :inventory_units, inverse_of: :carton
   has_many :orders, -> { uniq }, through: :inventory_units
+  has_many :shipments, -> { uniq }, through: :inventory_units
 
   validates :address, presence: true
   validates :stock_location, presence: true
@@ -34,5 +33,17 @@ class Spree::Carton < ActiveRecord::Base
 
   def order_emails
     orders.map(&:email).uniq
+  end
+
+  def shipment_numbers
+    shipments.map(&:number)
+  end
+
+  def display_shipped_at
+    shipped_at.to_s(:rfc822)
+  end
+
+  def manifest
+    @manifest ||= Spree::ShippingManifest.new(inventory_units: inventory_units).items
   end
 end

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -1,5 +1,8 @@
 module Spree
   class InventoryUnit < ActiveRecord::Base
+    PRE_SHIPMENT_STATES = %w(backordered on_hand)
+    POST_SHIPMENT_STATES = %w(returned)
+
     belongs_to :variant, class_name: "Spree::Variant", inverse_of: :inventory_units
     belongs_to :order, class_name: "Spree::Order", inverse_of: :inventory_units
     belongs_to :shipment, class_name: "Spree::Shipment", touch: true, inverse_of: :inventory_units
@@ -11,7 +14,9 @@ module Spree
 
     scope :backordered, -> { where state: 'backordered' }
     scope :on_hand, -> { where state: 'on_hand' }
+    scope :pre_shipment, -> { where(state: PRE_SHIPMENT_STATES) }
     scope :shipped, -> { where state: 'shipped' }
+    scope :post_shipment, -> { where(state: POST_SHIPMENT_STATES) }
     scope :returned, -> { where state: 'returned' }
     scope :backordered_per_variant, ->(stock_item) do
       includes(:shipment, :order)

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -83,6 +83,7 @@ module Spree
         return 0 if quantity == 0 || shipment.shipped?
 
         shipment_units = shipment.inventory_units_for_item(line_item, variant).reject do |variant_unit|
+          # TODO: exclude all 'shipped' states
           variant_unit.state == 'shipped'
         end.sort_by(&:state)
 

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -15,7 +15,7 @@ class Spree::OrderShipping
   # @return The carton created.
   def ship_shipment(shipment, external_number: nil, tracking_number: nil)
     ship(
-      inventory_units: shipment.inventory_units,
+      inventory_units: shipment.inventory_units.pre_shipment,
       stock_location: shipment.stock_location,
       address: shipment.address,
       shipping_method: shipment.shipping_method,

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -2,8 +2,6 @@ require 'ostruct'
 
 module Spree
   class Shipment < ActiveRecord::Base
-    include Spree::ShippingManifest
-
     belongs_to :order, class_name: 'Spree::Order', touch: true, inverse_of: :shipments
     belongs_to :address, class_name: 'Spree::Address', inverse_of: :shipments
     belongs_to :stock_location, class_name: 'Spree::StockLocation'
@@ -13,6 +11,7 @@ module Spree
     has_many :state_changes, as: :stateful
     has_many :inventory_units, dependent: :delete_all, inverse_of: :shipment
     has_many :adjustments, as: :adjustable, dependent: :delete_all
+    has_many :cartons, -> { uniq }, through: :inventory_units
 
     after_save :update_adjustments
 
@@ -178,6 +177,10 @@ module Spree
 
     def line_items
       inventory_units.includes(:line_item).map(&:line_item).uniq
+    end
+
+    def manifest
+      @manifest ||= Spree::ShippingManifest.new(inventory_units: inventory_units).items
     end
 
     def finalize!

--- a/core/app/models/spree/shipping_manifest.rb
+++ b/core/app/models/spree/shipping_manifest.rb
@@ -1,10 +1,14 @@
-module Spree::ShippingManifest
+class Spree::ShippingManifest
   ManifestItem = Struct.new(:line_item, :variant, :quantity, :states)
 
-  def manifest
+  def initialize(inventory_units:)
+    @inventory_units = inventory_units
+  end
+
+  def items
     # Grouping by the ID means that we don't have to call out to the association accessor
     # This makes the grouping by faster because it results in less SQL cache hits.
-    inventory_units.group_by(&:variant_id).map do |variant_id, units|
+    @inventory_units.group_by(&:variant_id).map do |variant_id, units|
       units.group_by(&:line_item_id).map do |line_item_id, units|
 
         states = {}

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1190,6 +1190,8 @@ en:
         thanks: Thank you for your business.
         track_information: ! 'Tracking Information: %{tracking}'
         track_link: ! 'Tracking Link: %{url}'
+    shipment_date: Shipment date
+    shipment_numbers: Shipment numbers
     shipment_state: Shipment State
     shipment_states:
       backorder: backorder

--- a/core/spec/models/spree/carton_spec.rb
+++ b/core/spec/models/spree/carton_spec.rb
@@ -51,6 +51,15 @@ describe Spree::Carton do
     end
   end
 
+  describe "#shipment_numbers" do
+    subject { carton.shipment_numbers }
+    let(:shipment) { carton.shipments.first }
+
+    it "returns a list of the order numbers it is associated to" do
+      expect(subject).to eq [shipment.number]
+    end
+  end
+
   describe "#order_emails" do
     subject { carton.order_emails }
 

--- a/core/spec/models/spree/order_shipping_spec.rb
+++ b/core/spec/models/spree/order_shipping_spec.rb
@@ -144,5 +144,29 @@ describe Spree::OrderShipping do
       end
     end
 
+    context "when the shipment has been partially shipped previously" do
+      let(:order) { create(:order_ready_to_ship, line_items_count: 2) }
+      let(:shipped_inventory) { [shipment.inventory_units.first] }
+      let(:unshipped_inventory) { [shipment.inventory_units.last] }
+
+      before do
+        order.shipping.ship(
+          inventory_units: shipped_inventory,
+          stock_location: shipment.stock_location,
+          address: shipment.address,
+          shipping_method: shipment.shipping_method,
+        )
+      end
+
+      it "marks the inventory units as shipped" do
+        expect { subject }.to change { unshipped_inventory.map(&:reload).map(&:state) }.from(['on_hand']).to(['shipped'])
+      end
+
+      it "creates a carton with the shipment's inventory units" do
+        expect { subject }.to change { order.cartons.count }.by(1)
+        expect(subject.inventory_units).to match_array(unshipped_inventory)
+      end
+    end
+
   end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -299,7 +299,7 @@ describe Spree::Shipment do
     end
 
     it 'restocks the items' do
-      shipment.stub_chain(inventory_units: [mock_model(Spree::InventoryUnit, state: "on_hand", line_item: line_item, variant: variant)])
+      variant = shipment.inventory_units.first.variant
       shipment.stock_location = mock_model(Spree::StockLocation)
       shipment.stock_location.should_receive(:restock).with(variant, 1, shipment)
       shipment.after_cancel
@@ -335,6 +335,8 @@ describe Spree::Shipment do
   end
 
   context "#resume" do
+    let(:inventory_unit) { create(:inventory_unit) }
+
     it 'will determine new state based on order' do
       shipment.order.stub(:update!)
 
@@ -346,7 +348,7 @@ describe Spree::Shipment do
     end
 
     it 'unstocks them items' do
-      shipment.stub_chain(inventory_units: [mock_model(Spree::InventoryUnit, line_item: line_item, variant: variant)])
+      variant = shipment.inventory_units.first.variant
       shipment.stock_location = mock_model(Spree::StockLocation)
       shipment.stock_location.should_receive(:unstock).with(variant, 1, shipment)
       shipment.after_resume


### PR DESCRIPTION
- When inventory is moved to a carton, display it with associated tracking info
- Continue to display unshipped shipments
- Cartons should be readonly
- Remove some abilities for editing shipments in admin

cc @jordan-brough @gmacdougall @cbrunsdon @jhawthorn 