### PR TITLE
Allow creating customer returns when some things have not shipped

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
@@ -7,6 +7,7 @@
       <th><%= Spree.t(:product) %></th>
       <th><%= Spree.t(:sku) %></th>
       <th><%= Spree.t(:pre_tax_amount) %></th>
+      <th><%= Spree.t(:state) %></th>
       <th><%= Spree.t(:exchange_for) %></th>
       <th><%= Spree.t(:resellable) %></th>
       <th><%= Spree.t(:reception_status) %></th>
@@ -34,6 +35,9 @@
         </td>
         <td class="align-center">
           <%= return_item.display_pre_tax_amount %>
+        </td>
+        <td class="align-center">
+          <%= return_item.inventory_unit.state %>
         </td>
         <td class="align-center">
           <%= return_item.exchange_variant.try(:options_text) %>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -1,11 +1,9 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
 
 <% content_for :page_actions do %>
-  <% if @order.shipments.any?(&:shipped?) %>
-    <li>
-      <%= button_link_to Spree.t(:new_customer_return), spree.new_admin_order_customer_return_path(@order), icon: 'plus' %>
-    </li>
-  <% end %>
+  <li>
+    <%= button_link_to Spree.t(:new_customer_return), spree.new_admin_order_customer_return_path(@order), icon: 'plus' %>
+  </li>
   <li><%= button_link_to Spree.t(:back_to_orders_list), spree.admin_orders_path, :icon => 'arrow-left' %></li>
 <% end %>
 
@@ -13,50 +11,42 @@
   <i class="fa fa-arrow-right"></i> <%= Spree.t(:customer_returns) %>
 <% end %>
 
-<% if @order.shipments.any?(&:shipped?) %>
-
-  <% if @customer_returns.any? %>
-    <table class="index">
-      <thead data-hook="customer_return_header">
-        <tr>
-          <th><%= Spree.t(:return_number) %></th>
-          <th><%= Spree.t(:pre_tax_total) %></th>
-          <th><%= Spree.t(:total) %></th>
-          <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
-          <th><%= Spree.t(:reimbursement_status) %></th>
-          <th class="actions"></th>
+<% if @customer_returns.any? %>
+  <table class="index">
+    <thead data-hook="customer_return_header">
+      <tr>
+        <th><%= Spree.t(:return_number) %></th>
+        <th><%= Spree.t(:pre_tax_total) %></th>
+        <th><%= Spree.t(:total) %></th>
+        <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
+        <th><%= Spree.t(:reimbursement_status) %></th>
+        <th class="actions"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @customer_returns.each do |customer_return| %>
+        <tr id="<%= spree_dom_id(customer_return) %>" data-hook="customer_return_row" class="<%= cycle('odd', 'even')%>">
+          <td><%= link_to customer_return.number, edit_admin_order_customer_return_path(@order, customer_return) %></td>
+          <td><%= customer_return.display_pre_tax_total.to_html %></td>
+          <td><%= customer_return.display_total.to_html %></td>
+          <td><%= pretty_time(customer_return.created_at) %></td>
+          <td>
+            <% if customer_return.fully_reimbursed? %>
+              <span class="state success"><%= Spree.t(:reimbursed) %></span>
+            <% else %>
+              <span class="state notice"><%= Spree.t(:incomplete) %></span>
+            <% end %>
+          </td>
+          <td class='actions align-center' data-hook="admin_orders_customer_returns_index_row_actions">
+            <%= link_to_edit_url edit_admin_order_customer_return_path(@order, customer_return), title: "admin_edit_#{dom_id(customer_return)}", no_text: true %>
+          </td>
         </tr>
-      </thead>
-      <tbody>
-        <% @customer_returns.each do |customer_return| %>
-          <tr id="<%= spree_dom_id(customer_return) %>" data-hook="customer_return_row" class="<%= cycle('odd', 'even')%>">
-            <td><%= link_to customer_return.number, edit_admin_order_customer_return_path(@order, customer_return) %></td>
-            <td><%= customer_return.display_pre_tax_total.to_html %></td>
-            <td><%= customer_return.display_total.to_html %></td>
-            <td><%= pretty_time(customer_return.created_at) %></td>
-            <td>
-              <% if customer_return.fully_reimbursed? %>
-                <span class="state success"><%= Spree.t(:reimbursed) %></span>
-              <% else %>
-                <span class="state notice"><%= Spree.t(:incomplete) %></span>
-              <% end %>
-            </td>
-            <td class='actions align-center' data-hook="admin_orders_customer_returns_index_row_actions">
-              <%= link_to_edit_url edit_admin_order_customer_return_path(@order, customer_return), title: "admin_edit_#{dom_id(customer_return)}", no_text: true %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  <% else %>
-    <div class="alpha twelve columns no-objects-found">
-      <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/customer_return')) %>,
-      <%= link_to Spree.t(:add_one), spree.new_admin_order_customer_return_path(@order) %>!
-    </div>
-  <% end %>
-
+      <% end %>
+    </tbody>
+  </table>
 <% else %>
-  <div data-hook="customer_return_cannot_create" class="no-objects-found">
-    <%= Spree.t(:cannot_create_customer_returns) %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/customer_return')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_order_customer_return_path(@order) %>!
   </div>
 <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -495,7 +495,6 @@ en:
     calculator_settings_warning: If you are changing the calculator type, you must save first before you can edit the calculator settings
     cancel: cancel
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
-    cannot_create_customer_returns: Cannot create customer returns as this order has no shipped units.
     cannot_create_returns: Cannot create returns as this order has no shipped units.
     cannot_perform_operation: Cannot perform requested operation
     cannot_set_shipping_method_without_address: Cannot set shipping method until customer details are provided.


### PR DESCRIPTION
With the carton work, cartons represent actual shipments, so a
Shipment may have some items that have shipped and others that
haven't, but everything has been charged.  You should still be able to
create a customer return in that case, so fix some code around that.

cc @philbirt @cbrunsdon @jhawthorn @gmacdougall 