### PR TITLE
This adds missing dependent :destroy on associations

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -6,8 +6,8 @@ module Spree
     belongs_to :carton, class_name: "Spree::Carton", inverse_of: :inventory_units
     belongs_to :line_item, class_name: "Spree::LineItem", inverse_of: :inventory_units
 
-    has_many :return_items, inverse_of: :inventory_unit
-    has_one :original_return_item, class_name: "Spree::ReturnItem", foreign_key: :exchange_inventory_unit_id
+    has_many :return_items, inverse_of: :inventory_unit, dependent: :destroy
+    has_one :original_return_item, class_name: "Spree::ReturnItem", foreign_key: :exchange_inventory_unit_id, dependent: :destroy
 
     scope :backordered, -> { where state: 'backordered' }
     scope :on_hand, -> { where state: 'on_hand' }

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -11,7 +11,7 @@ module Spree
     has_many :shipping_rates, -> { order('cost ASC') }, dependent: :delete_all
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
-    has_many :inventory_units, dependent: :delete_all, inverse_of: :shipment
+    has_many :inventory_units, dependent: :destroy, inverse_of: :shipment
     has_many :adjustments, as: :adjustable, dependent: :delete_all
 
     after_save :update_adjustments


### PR DESCRIPTION
This is required so that we do not leave return items that refer to
inventory units that no longer exist.