### PR TITLE
Debounce variant autocomplete request.

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee.erb
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee.erb
@@ -20,6 +20,7 @@ $.fn.variantAutocomplete = ->
     ajax:
       url: Spree.routes.variants_api
       datatype: "json"
+      quietMillis: 500
       params: { "headers": { "X-Spree-Token": Spree.api_key } }
       data: (term, page) ->
         q:


### PR DESCRIPTION
So that we don't fire off requests every time there is a change, rather
wait for a bit so the person might have finished typing.