### PR TITLE
Remove the current_api_user fallback to an unpersisted user.

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -41,11 +41,17 @@ module Spree
 
       # users should be able to set price when importing orders via api
       def permitted_line_item_attributes
-        if current_api_user.has_spree_role?("admin")
+        if is_admin?
           super + admin_line_item_attributes
         else
           super
         end
+      end
+
+      protected
+
+      def is_admin?
+        current_api_user && current_api_user.has_spree_role?("admin")
       end
 
       private
@@ -70,9 +76,6 @@ module Spree
             render "spree/api/errors/must_specify_api_key", :status => 401 and return
           elsif order_token.blank? && (requires_authentication? || api_key.present?)
             render "spree/api/errors/invalid_api_key", :status => 401 and return
-          else
-            # An anonymous user
-            @current_api_user = Spree.user_class.new
           end
         end
       end
@@ -130,7 +133,7 @@ module Spree
 
       def product_scope
         variants_associations = [{ option_values: :option_type }, :default_price, :prices, :images]
-        if current_api_user.has_spree_role?("admin")
+        if is_admin?
           scope = Product.with_deleted.accessible_by(current_ability, :read)
             .includes(:properties, :option_types, variants: variants_associations, master: variants_associations)
 

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -101,7 +101,7 @@ module Spree
         end
 
         def permitted_order_attributes
-          if current_api_user.has_spree_role? "admin"
+          if is_admin?
             super + admin_order_attributes
           else
             super
@@ -109,7 +109,7 @@ module Spree
         end
 
         def permitted_shipment_attributes
-          if current_api_user.has_spree_role? "admin"
+          if is_admin?
             super + admin_shipment_attributes
           else
             super

--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -51,14 +51,14 @@ module Spree
 
         def scope
           if @product
-            unless current_api_user.has_spree_role?('admin') || params[:show_deleted]
+            unless is_admin? || params[:show_deleted]
               variants = @product.variants_including_master.accessible_by(current_ability, :read)
             else
               variants = @product.variants_including_master.with_deleted.accessible_by(current_ability, :read)
             end
           else
             variants = Variant.accessible_by(current_ability, :read)
-            if current_api_user.has_spree_role?('admin')
+            if is_admin?
               unless params[:show_deleted]
                 variants = Variant.accessible_by(current_ability, :read).active
               end


### PR DESCRIPTION
It can create some surprising behavior when other code is checking for
the presence of current_api_user and there is one that exists but it is
not actually someone who is signed in.