### PR TITLE
Speed up specs by 9.5 minutes

### DIFF
--- a/api/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Api::LineItemsController do
     render_views
 
-    let!(:order) { create(:order_with_line_items) }
+    let!(:order) { create(:order_with_line_items, line_items_count: 1) }
 
     let(:product) { create(:product) }
     let(:attributes) { [:id, :quantity, :price, :variant, :total, :display_amount, :single_display_amount] }
@@ -55,7 +55,7 @@ module Spree
         api_post :create, :line_item => { :variant_id => product.master.to_param, :quantity => 1 }
         response.status.should == 201
         order.reload
-        order.line_items.count.should == 6 # 5 original due to factory, + 1 in this test
+        order.line_items.count.should == 2 # 1 originally + 1 in this test
         json_response.should have_attributes(attributes)
         json_response["quantity"].should == 11
       end
@@ -65,7 +65,7 @@ module Spree
         api_put :update, :id => line_item.id, :line_item => { :quantity => 101 }
         response.status.should == 200
         order.reload
-        order.total.should == 1050 # 50 original due to factory, + 1000 in this test
+        order.total.should == 1010 # 10 originally + 1000 in this test
         json_response.should have_attributes(attributes)
         json_response["quantity"].should == 101
       end
@@ -75,7 +75,7 @@ module Spree
         api_delete :destroy, :id => line_item.id
         response.status.should == 204
         order.reload
-        order.line_items.count.should == 4 # 5 original due to factory, - 1 in this test
+        order.line_items.count.should == 0 # 1 originally - 1 in this test
         lambda { line_item.reload }.should raise_error(ActiveRecord::RecordNotFound)
       end
 

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Adjustments" do
   stub_authorization!
 
-  let!(:order) { create(:completed_order_with_totals) }
+  let!(:order) { create(:completed_order_with_totals, line_items_count: 1) }
   let!(:line_item) do
     line_item = order.line_items.first
     # so we can be sure of a determinate price in our assertions
@@ -57,7 +57,7 @@ describe "Adjustments" do
         fill_in "adjustment_label", :with => "rebate"
         click_button "Continue"
         page.should have_content("successfully created!")
-        page.should have_content("Total: $90.00")
+        page.should have_content("Total: $50.00")
 
         order.reload.all_adjustments.each do |adjustment|
           expect(adjustment.order_id).to equal(order.id)
@@ -93,7 +93,7 @@ describe "Adjustments" do
           page.should have_content("$99.00")
         end
 
-        page.should have_content("Total: $169.00")
+        page.should have_content("Total: $129.00")
       end
     end
 
@@ -122,7 +122,7 @@ describe "Adjustments" do
         end
       end
 
-      page.should have_content(/TOTAL: ?\$80\.00/)
+      page.should have_content(/TOTAL: ?\$40\.00/)
     end
   end
 end

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -14,7 +14,7 @@ describe 'Payments' do
       )
     end
 
-    let(:order) { create(:completed_order_with_totals, number: 'R100') }
+    let(:order) { create(:completed_order_with_totals, number: 'R100', line_items_count: 1) }
     let(:state) { 'checkout' }
 
     before do
@@ -69,7 +69,7 @@ describe 'Payments' do
     it 'should be able to list and create payment methods for an order', js: true do
       find('#payment_status').text.should == 'PENDING'
       within_row(1) do
-        column_text(3).should == '$150.00'
+        column_text(3).should == '$110.00'
         column_text(4).should == 'Credit Card'
         column_text(6).should == 'CHECKOUT'
       end
@@ -81,7 +81,7 @@ describe 'Payments' do
       page.should have_content('Payment Updated')
 
       within_row(1) do
-        column_text(3).should == '$150.00'
+        column_text(3).should == '$110.00'
         column_text(4).should == 'Credit Card'
         column_text(6).should == 'VOID'
       end

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Shipments" do
   stub_authorization!
 
-  let!(:order) { create(:order_ready_to_ship, :number => "R100", :state => "complete") }
+  let!(:order) { create(:order_ready_to_ship, :number => "R100", :state => "complete", :line_items_count => 1) }
 
   # Regression test for #4025
   context "a shipment without a shipping method" do
@@ -38,6 +38,7 @@ describe "Shipments" do
   end
 
   context "moving variants between shipments", js: true do
+    let!(:order) { create(:order_ready_to_ship, :number => "R100", :state => "complete", :line_items_count => 5) }
     let!(:la) { create(:stock_location, name: "LA") }
     before(:each) do
       visit spree.admin_path

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -21,7 +21,7 @@ FactoryGirl.define do
       ship_address
 
       transient do
-        line_items_count 5
+        line_items_count 1
         shipment_cost 100
       end
 

--- a/core/lib/spree/testing_support/factories/return_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_item_factory.rb
@@ -1,7 +1,9 @@
 FactoryGirl.define do
   factory :return_item, class: Spree::ReturnItem do
     association(:inventory_unit, factory: :inventory_unit, state: :shipped)
-    association(:return_authorization, factory: :return_authorization)
+    return_authorization do |return_item|
+      build(:return_authorization, order: inventory_unit.order)
+    end
 
     factory :exchange_return_item do
       after(:build) do |return_item|

--- a/core/spec/models/spree/exchange_spec.rb
+++ b/core/spec/models/spree/exchange_spec.rb
@@ -30,9 +30,13 @@ module Spree
     end
 
     describe "#perform!" do
-      let(:return_item) { create(:exchange_return_item) }
+      let(:return_item) { create(:exchange_return_item, inventory_unit: inventory_unit) }
       let(:return_items) { [return_item] }
-      let(:order) { return_item.return_authorization.order }
+
+      let(:inventory_unit) { create(:inventory_unit, order: order, line_item: line_item) }
+      let(:order) { create(:shipped_order, line_items_count: 1) }
+      let(:line_item) { order.line_items.first }
+
       subject { exchange.perform! }
       before { return_item.exchange_variant.stock_items.first.adjust_count_on_hand(20) }
 

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Spree
   describe Spree::Order do
-    let(:order) { create(:order_with_line_items) }
+    let(:order) { create(:order_with_line_items, line_items_count: 5) }
     let(:updater) { Spree::OrderUpdater.new(order) }
 
     before do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -745,10 +745,10 @@ describe Spree::Order do
 
   describe '#quantity' do
     # Uses a persisted record, as the quantity is retrieved via a DB count
-    let(:order) { create :order_with_line_items }
+    let(:order) { create :order_with_line_items, line_items_count: 2 }
 
     it 'sums the quantity of all line items' do
-      expect(order.quantity).to eq 5
+      expect(order.quantity).to eq 2
     end
   end
 
@@ -760,15 +760,6 @@ describe Spree::Order do
       ]
 
       expect(subject.pre_tax_item_amount).to eq 19.0
-    end
-  end
-
-  describe '#quantity' do
-    # Uses a persisted record, as the quantity is retrieved via a DB count
-    let(:order) { create :order_with_line_items }
-
-    it 'sums the quantity of all line items' do
-      expect(order.quantity).to eq 5
     end
   end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -366,7 +366,13 @@ describe Spree::Shipment do
 
   context "#ship" do
     context "when the shipment is canceled" do
-      let(:shipment_with_inventory_units) { create(:shipment, order: create(:order_with_line_items), state: 'canceled') }
+      let(:shipment_with_inventory_units) do
+        create(
+          :shipment,
+          order: create(:order_with_line_items, line_items_count: 2),
+          state: 'canceled',
+        )
+      end
       let(:subject) { shipment_with_inventory_units.ship! }
       before do
         order.stub(:update!)
@@ -374,7 +380,7 @@ describe Spree::Shipment do
       end
 
       it 'unstocks them items' do
-        shipment_with_inventory_units.stock_location.should_receive(:unstock).exactly(5).times
+        shipment_with_inventory_units.stock_location.should_receive(:unstock).exactly(2).times
         subject
       end
     end

--- a/core/spec/models/spree/stock/packer_spec.rb
+++ b/core/spec/models/spree/stock/packer_spec.rb
@@ -49,7 +49,18 @@ module Spree
 
         context "doesn't track inventory levels" do
           let(:variant) { build(:variant) }
-          let(:inventory_units) { 30.times.map { build(:inventory_unit, variant: variant) } }
+          let(:order) { build(:order_with_line_items, line_items_count: 1) }
+          let(:line_item) { order.line_items.first }
+          let(:inventory_units) {
+            30.times.map do
+              build(
+                :inventory_unit,
+                order: order,
+                line_item: line_item,
+                variant: variant,
+              )
+            end
+          }
 
           before { Config.track_inventory_levels = false }
 

--- a/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
+++ b/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
@@ -5,19 +5,21 @@ module Spree
     module Splitter
       describe ShippingCategory do
 
+        let(:order) { create(:order_with_line_items, line_items_count: 1) }
+        let(:line_item) { order.line_items.first }
         let(:variant1) { build(:variant) }
         let(:variant2) { build(:variant) }
         let(:shipping_category_1) { create(:shipping_category, name: 'A') }
         let(:shipping_category_2) { create(:shipping_category, name: 'B') }
 
         def inventory_unit1
-          build(:inventory_unit, variant: variant1).tap do |inventory_unit|
+          build(:inventory_unit, variant: variant1, order: order, line_item: line_item).tap do |inventory_unit|
             inventory_unit.variant.product.shipping_category = shipping_category_1
           end
         end
 
         def inventory_unit2
-          build(:inventory_unit, variant: variant2).tap do |inventory_unit|
+          build(:inventory_unit, variant: variant2, order: order, line_item: line_item).tap do |inventory_unit|
             inventory_unit.variant.product.shipping_category = shipping_category_2
           end
         end


### PR DESCRIPTION
I went looking for some low-hanging fruit to speed up specs.  I found some. 

All these times are on my own computer.

Overall: 9.5min speedup (when run serially)

Core (7.5min speedup)
  - Before: 762s
  - After:  306s

Backend (92s speedup)
  - Before: 473s
  - After:  381s

API (26s speedup)
  - Before: 93s
  - After:  67s

Frontend (no change)
  - Before: 123s
  - After:  121s
