### PR TITLE
Fix bug with mixed variant stocking during purchase.

### DIFF
--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -59,8 +59,9 @@ module Spree
       # Returns an array of Package instances
       def build_packages(packages = Array.new)
         StockLocation.active.each do |stock_location|
-          next unless stock_location.stock_items.where(variant_id: unallocated_inventory_units.map(&:variant_id).uniq).exists?
-          packer = build_packer(stock_location, unallocated_inventory_units)
+          units_for_location = unallocated_inventory_units.select { |unit| stock_location.stock_item(unit.variant) }
+          next unless units_for_location.any?
+          packer = build_packer(stock_location, units_for_location)
           packages += packer.packages
         end
         packages

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -1,5 +1,6 @@
 module Spree
   class StockLocation < ActiveRecord::Base
+    class InvalidMovementError < StandardError; end
     has_many :shipments
     has_many :cartons, inverse_of: :stock_location
     has_many :stock_items, dependent: :delete_all
@@ -62,6 +63,9 @@ module Spree
     end
 
     def move(variant, quantity, originator = nil)
+      if quantity < 1 && !stock_item(variant)
+        raise InvalidMovementError.new(Spree.t(:negative_movement_absent_item))
+      end
       stock_item_or_create(variant).stock_movements.create!(quantity: quantity,
                                                             originator: originator)
     end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -823,6 +823,7 @@ en:
     name: Name
     name_on_card: Name on card
     name_or_sku: Name or SKU (enter at least first 4 characters of product name)
+    negative_movement_absent_item: Cannot create negative movement for absent stock item.
     new: New
     new_adjustment: New Adjustment
     new_customer: New Customer

--- a/core/spec/models/spree/stock/coordinator_spec.rb
+++ b/core/spec/models/spree/stock/coordinator_spec.rb
@@ -73,6 +73,44 @@ module Spree
           end
         end
       end
+
+      # regression spec
+      context "when there is one unit that has stock in a stock location that a non-tracked unit has no stock item in" do
+        let!(:stock_location_1) { create(:stock_location, propagate_all_variants: false, active: true) }
+        let!(:stock_location_2) { create(:stock_location, propagate_all_variants: false, active: true) }
+
+        let!(:variant_1) do
+          create(:variant, track_inventory: true).tap do |variant|
+            variant.stock_items.destroy_all
+            stock_item = variant.stock_items.create!(stock_location: stock_location_1)
+            stock_item.set_count_on_hand(10)
+          end
+        end
+        let!(:variant_2) do
+          create(:variant, track_inventory: false).tap do |variant|
+            variant.stock_items.destroy_all
+            stock_item = variant.stock_items.create!(stock_location: stock_location_2)
+            stock_item.set_count_on_hand(0)
+          end
+        end
+
+        let!(:order) { create(:order, line_items: [create(:line_item, variant: variant_1), create(:line_item, variant: variant_2)]) }
+
+        it "splits the inventory units to stock locations that they have stock items for" do
+          packages = subject.packages
+
+          expect(subject.packages.size).to eq 2
+
+          location_1_package = packages.detect { |p| p.stock_location == stock_location_1 }
+          location_2_package = packages.detect { |p| p.stock_location == stock_location_2 }
+
+          expect(location_1_package).to be_present
+          expect(location_2_package).to be_present
+
+          expect(location_1_package.contents.map(&:inventory_unit).map(&:variant)).to eq [variant_1]
+          expect(location_2_package.contents.map(&:inventory_unit).map(&:variant)).to eq [variant_2]
+        end
+      end
     end
   end
 end

--- a/core/spec/models/spree/stock_location_spec.rb
+++ b/core/spec/models/spree/stock_location_spec.rb
@@ -215,5 +215,36 @@ module Spree
         end
       end
     end
+
+    describe "#move" do
+      let!(:variant) { create(:variant) }
+      def move
+        subject.move(variant, quantity)
+      end
+
+      context "no stock item exists" do
+        before { subject.stock_items.destroy_all }
+        context "positive movement" do
+          let(:quantity) { 1 }
+          it "creates a stock item" do
+            expect { move }.to change { subject.stock_items.count }.by 1
+          end
+        end
+
+        # We should not be creating stock items that do not exist
+        # for the sake of a negative movement.
+        context "negative movement" do
+          let(:quantity) { -1 }
+          it "raises an error" do
+            expect {
+              expect {
+                move
+              }.to raise_error StockLocation::InvalidMovementError
+            }.not_to change { subject.stock_items.count }
+          end
+        end
+
+      end
+    end
   end
 end


### PR DESCRIPTION
Here is the bug:
1) An order is placed for two items, 1 of which tracks inventory, and
the other of which does not track inventory at the first variant's stock
location.
2) The shipment building process packs both items into a shipment for
the stock location for the first item, even though the second item has
no stock location, due to incorrect checking of configured stock in the
Stock::Coordinator.
3) Shipment#finalize! calls manifest_unstock, which then calls
StockLocation#move, which will go ahead and create a stock item for the
variant / stock location in order to do a stock movement.

This results in:
1) The variant that does not track inventory being fulfilled from a stock
location that it is not configured to be fulfilled from.
2) That same variant now has a stock item in the stock location it
previously was not configured to be fulfilled from, and can easily be
purchased from it going forward.

The fix put in place here is:
1) Fix the bad logic in the Stock::Coordinator to only pack inventory
units to the stock locations that the variant has a stock item for.
2) Disallow the creation of new stock items for variants in a stock location
when making a non-positive stock movement.