### PR TITLE
Bug Fix for return items from unreturned item charge

### DIFF
--- a/core/app/models/spree/return_item/eligibility_validator/no_reimbursements.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/no_reimbursements.rb
@@ -1,7 +1,7 @@
 module Spree
   class ReturnItem::EligibilityValidator::NoReimbursements < Spree::ReturnItem::EligibilityValidator::BaseValidator
     def eligible_for_return?
-      if Spree::ReturnItem.where(inventory_unit: @return_item.inventory_unit).where.not(reimbursement_id: nil).any?
+      if @return_item.inventory_unit.return_items.reimbursed.not_expired.any?
         add_error(:inventory_unit_reimbursed, Spree.t('return_item_inventory_unit_reimbursed'))
         return false
       else

--- a/core/spec/models/spree/return_item/eligibility_validator/no_reimbursements_spec.rb
+++ b/core/spec/models/spree/return_item/eligibility_validator/no_reimbursements_spec.rb
@@ -19,6 +19,14 @@ describe Spree::ReturnItem::EligibilityValidator::NoReimbursements do
         subject
         expect(validator.errors[:inventory_unit_reimbursed]).to eq Spree.t('return_item_inventory_unit_reimbursed')
       end
+
+      context "but the return item has been expired" do
+        before { return_item.expired }
+
+        it "returns true" do
+          expect(subject).to eq true
+        end
+      end
     end
 
     context "inventory unit has not been reimbursed" do


### PR DESCRIPTION
Fixes a bug where return items that have been reimbursed and expired (through an unreturned exchange charge) go to manual intervention instead of automatically reimbursing when the item is returned. 

* Added scope to return item eligibility validator
* Added spec