### PR TITLE
Stop making routes terribly in resource controller

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -211,19 +211,21 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     end
 
     def edit_object_url(object, options = {})
+
       if parent_data.present?
-        spree.send "edit_admin_#{model_name}_#{object_name}_url", parent, object, options
+        spree.polymorphic_url([:edit, :admin, parent, object], options)
       else
-        spree.send "edit_admin_#{object_name}_url", object, options
+        spree.polymorphic_url([:edit, :admin, object], options)
       end
     end
 
     def object_url(object = nil, options = {})
       target = object ? object : @object
+
       if parent_data.present?
-        spree.send "admin_#{model_name}_#{object_name}_url", parent, target, options
+        spree.polymorphic_url([:admin, parent, target], options)
       else
-        spree.send "admin_#{object_name}_url", target, options
+        spree.polymorphic_url([:admin, target], options)
       end
     end
 

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -39,8 +39,8 @@
           <td class="align-center"><%= method.display_on.blank? ? Spree.t(:both) : Spree.t(method.display_on) %></td>
           <td class="align-center"><%= method.active ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
           <td data-hook="admin_payment_methods_index_row_actions" class="actions">
-            <%= link_to_edit method, :no_text => true %>
-            <%= link_to_delete method, :no_text => true  %>
+            <%= link_to_edit method.becomes(Spree::PaymentMethod), :no_text => true %>
+            <%= link_to_delete method.becomes(Spree::PaymentMethod), :no_text => true  %>
           </td>
         </tr>
       <% end %>

--- a/backend/app/views/spree/admin/taxonomies/_list.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/_list.html.erb
@@ -17,7 +17,7 @@
         <td class="no-border"><span class="handle"></span></td>
         <td class="align-center"><%= taxonomy.name %></td>
         <td class="actions">
-          <%= link_to_edit taxonomy.id, :no_text => true %>
+          <%= link_to_edit taxonomy, :no_text => true %>
           <%= link_to_delete taxonomy, :no_text => true %>
         </td>
       </tr>

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -14,6 +14,10 @@ module Spree
       true
     end
 
+    def self.model_name
+      ActiveModel::Name.new Spree::LegacyUser, Spree, 'user'
+    end
+
     attr_accessor :password
     attr_accessor :password_confirmation
 


### PR DESCRIPTION
I should have fixed this years ago. Years and years ago. Its right in
other places in this controller. Just not for these two.

Now you can make spree admin controllers to manage other namespaces
objects and it will actually work with the resource controller.