### PR TITLE
Move table_filter partial within the main content in the admin layout

### DIFF
--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -36,9 +36,8 @@
       <div class="container">
         <div class="row">
           <div class="<%= 'with-sidebar ' if content_for?(:sidebar) %>" id="content" data-hook>
-            <%= render :partial => 'spree/admin/shared/table_filter' %>
-
             <div class="<%= if content_for?(:sidebar) then 'twelve' else 'sixteen' end %> columns">
+              <%= render :partial => 'spree/admin/shared/table_filter' %>
               <%= yield %>
             </div>
 


### PR DESCRIPTION
When adding a table filter to a page with a sidebar that table filter should be part of the twelve column wrapper div that encloses the table.

Having the table_filter outside the main content can lead to visual issues where there is not enough space for the sidebar and it’s displayed after the table rather than next to the table_filter.