### PR TITLE
Stock transfers mgmt

### DIFF
--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -1,24 +1,7 @@
 module Spree
   module Admin
-    class StockTransfersController < Admin::BaseController
-      before_filter :load_stock_locations, :only => :index
-
-      def index
-        @q = StockTransfer.ransack(params[:q])
-
-        @stock_transfers = @q.result
-                             .includes(:stock_movements => { :stock_item => :stock_location })
-                             .order('created_at DESC')
-                             .page(params[:page])
-      end
-
-      def show
-        @stock_transfer = StockTransfer.find_by_param(params[:id])
-      end
-
-      def new
-
-      end
+    class StockTransfersController < ResourceController
+      before_filter :load_stock_locations, only: [:index]
 
       def create
         variants = Hash.new(0)
@@ -35,9 +18,20 @@ module Spree
         redirect_to admin_stock_transfer_path(stock_transfer)
       end
 
+      protected
+
+      def collection
+        params[:q] = params[:q] || {}
+        @search = super.ransack(params[:q])
+        @search.result.
+          page(params[:page]).
+          per(params[:per_page] || Spree::Config[:orders_per_page])
+      end
+
       private
+
       def load_stock_locations
-        @stock_locations = Spree::StockLocation.active.order_default
+        @stock_locations = Spree::StockLocation.accessible_by(current_ability, :index)
       end
 
       def source_location

--- a/backend/app/helpers/spree/admin/stock_transfers_helper.rb
+++ b/backend/app/helpers/spree/admin/stock_transfers_helper.rb
@@ -1,0 +1,17 @@
+module Spree
+  module Admin
+    module StockTransfersHelper
+      def handle_stock_transfer(stock_transfer)
+        if can?(:show, stock_transfer)
+          link_to stock_transfer.number, admin_stock_transfer_path(stock_transfer)
+        else
+          stock_transfer.number
+        end
+      end
+
+      def status(stock_transfer)
+        stock_transfer.closed? ? Spree.t(:closed) : Spree.t(:open)
+      end
+    end
+  end
+end

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -1,5 +1,3 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
-
 <% content_for :page_title do %>
   <%= Spree.t(:stock_transfers) %>
 <% end %>
@@ -10,33 +8,46 @@
   </li>
 <% end %>
 
-<div data-hook="admin_orders_index_search">
-  <fieldset>
-    <legend align="center"><%= Spree.t(:search) %></legend>
-    <%= search_form_for @q, :url => admin_stock_transfers_path do |f| %>
+<% content_for :table_filter_title do %>
+  <%= Spree.t(:search) %>
+<% end %>
+
+<% content_for :table_filter do %>
+  <div data-hook="admin_stock_transfers_index_search">
+    <%= search_form_for [:admin, @search] do |f| %>
+      <div class="field-block alpha four columns">
+        <div class="field">
+          <%= f.label nil, Spree.t(:stock_location) %>
+          <%= f.select :source_location_id_or_destination_location_id_eq, options_from_collection_for_select(@stock_locations, :id, :name, params[:q][:source_location_id_or_destination_location_id_eq]), {include_blank: true}, {class: 'select2 fullwidth'} %>
+        </div>
+      </div>
+
+      <div class="field-block alpha four columns">
+        <div class="date-range-filter field">
+          <%= f.label nil, Spree.t(:date_range) %>
+          <div class="date-range-fields">
+            <%= f.text_field :created_at_gt, class: 'datepicker datepicker-from', include_blank: true, value: params[:q][:created_at_gt], placeholder: Spree.t(:start) %>
+
+            <span class="range-divider">
+              <i class="fa fa-arrow-right"></i>
+            </span>
+
+            <%= f.text_field :created_at_lt, class: 'datepicker datepicker-to', include_blank: true, value: params[:q][:created_at_lt], placeholder: Spree.t(:stop) %>
+          </div>
+        </div>
+      </div>
 
       <div class="field-block alpha four columns">
         <div class="field">
-          <%= f.label :reference_cont, Spree.t(:reference_cont) %>
-          <%= f.text_field :reference_cont, class: 'fullwidth' %>
+          <%= f.label nil, Spree.t(:transfer_number) %>
+          <%= f.text_field :number_cont, value: params[:q][:number_cont] %>
         </div>
       </div>
 
-      <div class="four columns">
+      <div class="field-block alpha four columns">
         <div class="field">
-          <%= f.label :source_location, Spree.t(:source) %>
-          <%= f.select :source_location_id_eq,
-               options_from_collection_for_select(@stock_locations, :id, :name, @q.source_location_id_eq),
-               { include_blank: true }, class: 'select2 fullwidth' %>
-        </div>
-      </div>
-
-      <div class="omega four columns">
-        <div class="field">
-          <%= f.label :destination_location, Spree.t(:destination) %>
-          <%= f.select :destination_location_id_eq,
-               options_from_collection_for_select(@stock_locations, :id, :name, @q.destination_location_id_eq),
-               { include_blank: true }, class: 'select2 fullwidth' %>
+          <%= f.label nil, Spree.t(:status) %>
+          <%= f.select :closed_at_null, options_for_select([[Spree.t(:open), 1],[Spree.t(:closed), 0]], params[:q][:closed_at_null]), {include_blank: true}, {class: 'select2 fullwidth'} %>
         </div>
       </div>
 
@@ -48,48 +59,54 @@
         </div>
       </div>
     <% end %>
-  </fieldset>
-</div>
+  </div>
+<% end %>
+
+<%= paginate @stock_transfers %>
+
 
 <% if @stock_transfers.any? %>
-  <table class='index' id='listing_stock_transfers' data-hook>
-    <colgroup>
-      <col style='width: 25%' />
-      <col style='width: 20%' />
-      <col style='width: 20%' />
-      <col style='width: 25%' />
-      <col style='width: 10%' />
-    </colgroup>
+  <table class="index" id="listing_stock_transfers">
     <thead>
-      <tr data-hook='stock_transfers_header'>
-        <th><%= Spree.t(:created_at) %></th>
-        <th><%= Spree.t(:reference) %></th>
-        <th><%= Spree.t(:source) %></th>
-        <th><%= Spree.t(:destination) %></th>
-        <th class='actions'></th>
+      <tr>
+        <th><%= sort_link @search, :created_at,      Spree.t(:date) %></th>
+        <th><%= sort_link @search, :from,            Spree.t(:from) %></th>
+        <th><%= sort_link @search, :to,              Spree.t(:to) %></th>
+        <th><%= sort_link @search, :number,          Spree.t(:number) %></th>
+        <th><%= sort_link @search, :shipment_date,   Spree.t(:shipment_date) %></th>
+        <th><%= sort_link @search, :expected_items,  Spree.t(:expected_items) %></th>
+        <th><%= sort_link @search, :received_items,  Spree.t(:received_items) %></th>
+        <th><%= sort_link @search, :status,          Spree.t(:status) %></th>
+        <th class="actions"></th>
       </tr>
     </thead>
     <tbody>
       <% @stock_transfers.each do |stock_transfer| %>
-        <tr id="<%= spree_dom_id stock_transfer %>" data-hook="stock_transfer_row" class="<%= cycle('odd', 'even')%>">
-          <td class="align-center"><%= stock_transfer.created_at %></td>
-          <td class="align-center"><%= stock_transfer.reference %></td>
-          <td class="align-center"><%= stock_transfer.source_location.try(:name) %></td>
-          <td class="align-center"><%= stock_transfer.destination_location.try(:name) %></td>
-          <td class='actions'>
-            <%= link_to '', admin_stock_transfer_path(stock_transfer),
-            title: 'view', class: 'view icon_link with-tip fa fa-eye-open no-text',
-            data: {action: 'view'} %>
+        <tr id="<%= spree_dom_id stock_transfer %>" class="<%= cycle('odd', 'even') %>">
+          <td><%= stock_transfer.created_at.to_date %></td>
+          <td><%= stock_transfer.source_location.try(:name) %></td>
+          <td><%= stock_transfer.destination_location.name %></td>
+          <td><%= handle_stock_transfer(stock_transfer) %></td>
+          <td><%= stock_transfer.shipped_at %></td>
+          <td class="align-center"><%= stock_transfer.expected_item_count %></td>
+          <td class="align-center"><%= stock_transfer.received_item_count %></td>
+          <td><%= status(stock_transfer) %></td>
+          <td class="actions">
+          <% if stock_transfer.closed_at? %>
+            <%= link_to_with_icon 'view', Spree.t(:show), '#', :no_text => true, :data => {:action => 'show'} if can?(:show, stock_transfer) %>
+          <% else %>
+            <%= link_to_with_icon 'download', Spree.t(:receive), '#', :no_text => true %>
+          <% end %>
           </td>
         </tr>
       <% end %>
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/stock_transfer')) %>,
-    <%= link_to Spree.t(:add_one), spree.new_admin_stock_transfer_path %>!
+  <div class="alpha sixteen columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/stock_transfer')) %>
   </div>
 <% end %>
 
 <%= paginate @stock_transfers %>
+

--- a/backend/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
@@ -4,35 +4,33 @@ module Spree
   describe Admin::StockTransfersController do
     stub_authorization!
 
+    let(:warehouse) { StockLocation.create(name: "Warehouse")}
+    let(:ny_store) { StockLocation.create(name: "NY Store")}
+    let(:la_store) { StockLocation.create(name: "LA Store")}
+
     let!(:stock_transfer1) {
       StockTransfer.create do |transfer|
-        transfer.source_location_id = 1
-        transfer.destination_location_id = 2
-        transfer.reference = 'PO 666'
+        transfer.source_location_id = warehouse.id
+        transfer.destination_location_id = ny_store.id
       end }
 
     let!(:stock_transfer2) {
       StockTransfer.create do |transfer|
-        transfer.source_location_id = 3
-        transfer.destination_location_id = 4
-        transfer.reference = 'PO 666'
+        transfer.source_location_id = warehouse.id
+        transfer.destination_location_id = la_store.id
+        transfer.closed_at = DateTime.now
       end }
 
 
     context "#index" do
-      it "gets all transfers without search criteria" do
-        spree_get :index
-        assigns[:stock_transfers].count.should eq 2
-      end
-
-      it "searches by source location" do
-        spree_get :index, :q => { :source_location_id_eq => 1 }
+      it "searches by stock location" do
+        spree_get :index, :q => { :source_location_id_or_destination_location_id_eq => ny_store.id }
         assigns[:stock_transfers].count.should eq 1
         assigns[:stock_transfers].should include(stock_transfer1)
       end
 
-      it "searches by destination location" do
-        spree_get :index, :q => { :destination_location_id_eq => 4 }
+      it "searches by status" do
+        spree_get :index, :q => { :closed_at_null => 0 }
         assigns[:stock_transfers].count.should eq 1
         assigns[:stock_transfers].should include(stock_transfer2)
       end

--- a/backend/spec/features/admin/stock_transfer_spec.rb
+++ b/backend/spec/features/admin/stock_transfer_spec.rb
@@ -14,7 +14,6 @@ describe 'Stock Transfers', :js => true do
     click_button 'Add'
     click_button 'Transfer Stock'
 
-    page.should have_content('STOCK TRANSFER REFERENCE PO 666')
     page.should have_content('NY')
     page.should have_content('SF')
 
@@ -24,9 +23,8 @@ describe 'Stock Transfers', :js => true do
 
   describe 'received stock transfer' do
     def it_is_received_stock_transfer(page)
-      page.should have_content('STOCK TRANSFER REFERENCE PO 666')
-      page.should_not have_selector("#stock-location-source")
-      page.should have_selector("#stock-location-destination")
+      page.should_not have_content("San Francisco")
+      page.should have_content("New York")
 
       transfer = Spree::StockTransfer.last
       expect(transfer.stock_movements.size).to eq 1
@@ -34,14 +32,14 @@ describe 'Stock Transfers', :js => true do
     end
 
     it 'receive stock to a single location' do
-      source_location = create(:stock_location_with_items, :name => 'NY')
-      destination_location = create(:stock_location, :name => 'SF')
+      source_location = create(:stock_location_with_items, :name => 'New York')
+      destination_location = create(:stock_location, :name => 'San Francisco')
 
       visit spree.new_admin_stock_transfer_path
 
       fill_in 'reference', :with => 'PO 666'
       check 'transfer_receive_stock'
-      select('NY', :from => 'transfer_destination_location_id')
+      select('New York', :from => 'transfer_destination_location_id')
 
       click_button 'Add'
       click_button 'Transfer Stock'
@@ -50,13 +48,13 @@ describe 'Stock Transfers', :js => true do
     end
 
     it 'forced to only receive there is only one location' do
-      source_location = create(:stock_location_with_items, :name => 'NY')
+      source_location = create(:stock_location_with_items, :name => 'New York')
 
       visit spree.new_admin_stock_transfer_path
 
       fill_in 'reference', :with => 'PO 666'
 
-      select('NY', :from => 'transfer_destination_location_id')
+      select('New York', :from => 'transfer_destination_location_id')
 
       click_button 'Add'
       click_button 'Transfer Stock'

--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -18,6 +18,18 @@ module Spree
       number
     end
 
+    def ship(tracking_number: tracking_number, shipped_at: shipped_at)
+      update_attributes!(tracking_number: tracking_number, shipped_at: shipped_at)
+    end
+
+    def received_item_count
+      transfer_items.sum(:received_quantity)
+    end
+
+    def expected_item_count
+      transfer_items.sum(:expected_quantity)
+    end
+
     def source_movements
       stock_movements.joins(:stock_item)
         .where('spree_stock_items.stock_location_id' => source_location_id)

--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -1,11 +1,18 @@
 module Spree
   class StockTransfer < ActiveRecord::Base
     has_many :stock_movements, :as => :originator
+    has_many :transfer_items
 
-    belongs_to :source_location, :class_name => 'StockLocation'
-    belongs_to :destination_location, :class_name => 'StockLocation'
+    belongs_to :created_by, :class_name => 'Spree::User'
+    belongs_to :closed_by, :class_name => 'Spree::User'
+    belongs_to :source_location, :class_name => 'Spree::StockLocation'
+    belongs_to :destination_location, :class_name => 'Spree::StockLocation'
 
     make_permalink field: :number, prefix: 'T'
+
+    def closed?
+      closed_at.present?
+    end
 
     def to_param
       number

--- a/core/app/models/spree/transfer_item.rb
+++ b/core/app/models/spree/transfer_item.rb
@@ -1,0 +1,11 @@
+module Spree
+  class TransferItem < ActiveRecord::Base
+    belongs_to :stock_transfer
+    belongs_to :variant
+
+    validates_presence_of :stock_transfer, :variant
+
+    scope :received, -> { where('expected_quantity = received_quantity') }
+
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -679,6 +679,7 @@ en:
       count_on_hand_setter: Cannot set count_on_hand manually, as it is set automatically by the recalculate_count_on_hand callback. Please use `update_column(:count_on_hand, value)` instead.
     exchange_for: Exchange for
     expedited_exchanges_warning: "Any specified exchanges will ship to the customer immediately upon saving. The customer will be charged the full amount of the item if they do not return the original item within %{days_window} days."
+    expected_items: Expected Items
     expiration: Expiration
     extension: Extension
     existing_shipments: Existing shipments
@@ -895,6 +896,7 @@ en:
       variant_deleted: Variant has been deleted
       variant_not_deleted: Variant could not be deleted
     num_orders: "# Orders"
+    number: Number
     number_of_codes: ! '%{count} codes'
     on_hand: On Hand
     open: Open
@@ -1089,6 +1091,7 @@ en:
     receive: receive
     receive_stock: Receive Stock
     received: Received
+    received_items: Received Items
     reception_status: Reception Status
     reference: Reference
     refund: Refund
@@ -1185,6 +1188,7 @@ en:
     ship_total: Ship Total
     shipment: Shipment
     shipment_adjustments: "Shipment adjustments"
+    shipment_date: Shipment Date
     shipment_details: "From %{stock_location} via %{shipping_method}"
     shipment_inc_vat: Shipment including VAT
     shipment_mailer:
@@ -1309,6 +1313,7 @@ en:
     tiered_flat_rate: Tiered Flat Rate
     tiered_percent: Tiered Percent
     time: Time
+    to: to
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total
     total_per_item: Total per item
@@ -1324,6 +1329,7 @@ en:
     transfer_from_location: Transfer From
     transfer_stock: Transfer Stock
     transfer_to_location: Transfer To
+    transfer_number: Transfer Number
     tree: Tree
     type: Type
     type_to_search: Type to search

--- a/core/db/migrate/20150407173305_add_fields_to_stock_transfer.rb
+++ b/core/db/migrate/20150407173305_add_fields_to_stock_transfer.rb
@@ -1,0 +1,12 @@
+class AddFieldsToStockTransfer < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_transfers, :shipped_at, :datetime
+    add_column :spree_stock_transfers, :closed_at, :datetime
+    add_column :spree_stock_transfers, :tracking_number, :string
+    add_column :spree_stock_transfers, :created_by_id, :integer
+    add_column :spree_stock_transfers, :closed_by_id, :integer
+
+    add_index :spree_stock_transfers, :shipped_at
+    add_index :spree_stock_transfers, :closed_at
+  end
+end

--- a/core/db/migrate/20150407173531_create_transfer_items.rb
+++ b/core/db/migrate/20150407173531_create_transfer_items.rb
@@ -1,0 +1,14 @@
+class CreateTransferItems < ActiveRecord::Migration
+  def change
+    create_table :spree_transfer_items do |t|
+      t.integer :variant_id, null: false
+      t.integer :stock_transfer_id, null: false
+      t.integer :expected_quantity, null: false, default: 0
+      t.integer :received_quantity, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :spree_transfer_items, :stock_transfer_id
+    add_index :spree_transfer_items, :variant_id
+  end
+end

--- a/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :stock_transfer, class: Spree::StockTransfer do
+    source_location      Spree::StockLocation.new(name: "Source Location", code: "SRC")
+    destination_location Spree::StockLocation.new(name: "Destination Location", code: "DEST")
+
+    factory :stock_transfer_with_items do
+      after(:create) do |stock_transfer, evaluator|
+         variant_1 = create(:variant)
+         variant_2 = create(:variant)
+
+         stock_transfer.transfer_items.create(variant: variant_1)
+         stock_transfer.transfer_items.create(variant: variant_2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Beginning of adding more administrable functionality for stock transfers; currently builds out the initial modeling for stock transfers and added transfer items, and provides an index for viewing based on stock locations.

* Stock Transfers have shipped_at, tracking number, and closed_at fields
* Stock Transfers have transfer items, which can be indicated as being received_at
* Transfer Items belongs to variant, stock transfer, and stock location
* Stock Locations have many transfer items & specs

* Added searchable index view for stock transfers
* Stock Transfer controller inherits from resource controller
* Added translations
* Added and updated specs