### PR TITLE
Invalidate promo codes on completed orders.

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -60,6 +60,7 @@ module Spree
     scope :charge, -> { where("#{quoted_table_name}.amount >= 0") }
     scope :credit, -> { where("#{quoted_table_name}.amount < 0") }
     scope :promotion, -> { where(source_type: 'Spree::PromotionAction') }
+    scope :non_promotion, -> { where.not(source_type: 'Spree::PromotionAction') }
     scope :return_authorization, -> { where(source_type: "Spree::ReturnAuthorization") }
     scope :included, -> { where(included: true)  }
     scope :additional, -> { where(included: false) }

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -563,6 +563,13 @@ module Spree
         end
       end
 
+      def ensure_promotions_eligible
+        updater.update_adjustment_total
+        if promo_total_changed?
+          errors.add(:base, Spree.t(:promotion_total_changed_before_complete)) and return false
+        end
+      end
+
       def validate_line_item_availability
         availability_validator = Spree::Stock::AvailabilityValidator.new
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -566,8 +566,10 @@ module Spree
       def ensure_promotions_eligible
         updater.update_adjustment_total
         if promo_total_changed?
-          errors.add(:base, Spree.t(:promotion_total_changed_before_complete)) and return false
+          restart_checkout_flow
+          errors.add(:base, Spree.t(:promotion_total_changed_before_complete))
         end
+        errors.empty?
       end
 
       def validate_line_item_availability

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -77,6 +77,7 @@ module Spree
               before_transition to: :complete, do: :validate_line_item_availability, unless: :unreturned_exchange?
               before_transition to: :complete, do: :ensure_inventory_units, unless: :unreturned_exchange?
               before_transition to: :complete, do: :ensure_available_shipping_rates
+              before_transition to: :complete, do: :ensure_promotions_eligible
 
               if states[:payment]
                 event :payment_failed do

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -104,7 +104,7 @@ module Spree
     # called anytime order.update! happens
     def eligible?(promotable, promotion_code: nil)
       return false if expired?
-      return false if usage_limit_exceeded?(promotable)
+      return false if usage_limit_exceeded?
       return false if promotion_code && promotion_code.usage_limit_exceeded?
       return false if blacklisted?(promotable)
       !!eligible_rules(promotable, {})
@@ -131,20 +131,12 @@ module Spree
       end
     end
 
-    # Whether the given promotable would violate the usage restrictions
+    # Whether the promotion has exceeded it's usage restrictions.
     #
-    # @param promotable object (e.g. order/line item/shipment)
     # @return true or false
-    def usage_limit_exceeded?(promotable)
-      # TODO: This logic appears to be wrong.
-      # Currently if you have:
-      # - 2 different line item level actions on a promotion
-      # - 2 line items in an order
-      # Then using the promo on that order will create 4 adjustments and count as 4
-      # usages.
-      # See also PromotionCode#usage_limit_exceeded?
+    def usage_limit_exceeded?
       if usage_limit
-        usage_count - usage_count_for(promotable) >= usage_limit
+        usage_count >= usage_limit
       end
     end
 
@@ -152,7 +144,13 @@ module Spree
     #
     # @return [Integer] usage count
     def usage_count
-      adjustment_promotion_scope(Spree::Adjustment.eligible).count
+      Spree::Adjustment.eligible.
+        promotion.
+        where(source_id: actions.map(&:id)).
+        joins(:order).
+        merge(Spree::Order.complete).
+        distinct.
+        count(:order_id)
     end
 
     def used_by?(user, excluded_orders = [])
@@ -185,20 +183,12 @@ module Spree
       end
     end
 
-    def adjustment_promotion_scope(adjustment_scope)
-      adjustment_scope.promotion.where(source_id: actions.map(&:id))
-    end
-
     def normalize_blank_values
       self[:path] = nil if self[:path].blank?
     end
 
     def match_all?
       match_policy == 'all'
-    end
-
-    def usage_count_for(promotable)
-      adjustment_promotion_scope(promotable.adjustments).count
     end
   end
 end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -105,7 +105,7 @@ module Spree
     def eligible?(promotable, promotion_code: nil)
       return false if expired?
       return false if usage_limit_exceeded?(promotable)
-      return false if promotion_code && promotion_code.usage_limit_exceeded?(promotable)
+      return false if promotion_code && promotion_code.usage_limit_exceeded?
       return false if blacklisted?(promotable)
       !!eligible_rules(promotable, {})
     end

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -9,9 +9,8 @@ class Spree::PromotionCode < ActiveRecord::Base
 
   # Whether the promotion code has exceeded its usage restrictions
   #
-  # @param promotable object (e.g. order/line item/shipment) No longer used.
   # @return true or false
-  def usage_limit_exceeded?(promotable = nil)
+  def usage_limit_exceeded?
     if usage_limit
       usage_count >= usage_limit
     end
@@ -36,8 +35,5 @@ class Spree::PromotionCode < ActiveRecord::Base
 
   def downcase_value
     self.value = value.downcase
-  end
-
-  def adjustment_promotion_scope(adjustment_scope)
   end
 end

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -35,7 +35,7 @@ class Spree::PromotionCode < ActiveRecord::Base
   private
 
   def usage_count_for(promotable)
-    adjustment_promotion_scope(promotable.adjustments).
+    adjustment_promotion_scope(promotable.adjustments.eligible).
       joins(:order).
       merge(Spree::Order.complete).
       distinct.

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -35,8 +35,11 @@ class Spree::PromotionCode < ActiveRecord::Base
   private
 
   def usage_count_for(promotable)
-    return 0 if promotable.is_a?(Spree::Order) && !promotable.completed?
-    adjustment_promotion_scope(promotable.adjustments).count
+    adjustment_promotion_scope(promotable.adjustments).
+      joins(:order).
+      merge(Spree::Order.complete).
+      distinct.
+      count(:order_id)
   end
 
   def downcase_value

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -43,7 +43,7 @@ module Spree
       end
 
       def handle_present_promotion(promotion)
-        return promotion_usage_limit_exceeded if promotion.usage_limit_exceeded?(order) || promotion_code.usage_limit_exceeded?
+        return promotion_usage_limit_exceeded if promotion.usage_limit_exceeded? || promotion_code.usage_limit_exceeded?
         return promotion_applied if promotion_exists_on_order?(order, promotion)
         return ineligible_for_this_order unless promotion.eligible?(order, promotion_code: promotion_code)
 

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -43,7 +43,7 @@ module Spree
       end
 
       def handle_present_promotion(promotion)
-        return promotion_usage_limit_exceeded if promotion.usage_limit_exceeded?(order) || promotion_code.usage_limit_exceeded?(order)
+        return promotion_usage_limit_exceeded if promotion.usage_limit_exceeded?(order) || promotion_code.usage_limit_exceeded?
         return promotion_applied if promotion_exists_on_order?(order, promotion)
         return ineligible_for_this_order unless promotion.eligible?(order, promotion_code: promotion_code)
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1115,6 +1115,7 @@ en:
         name: User Logged In
     promotions: Promotions
     promotion_successfully_created: Promotion has been successfully created!
+    promotion_total_changed_before_complete: "One or more of the promotions on your order have become ineligible and were removed. Please check the new order amounts and try again."
     promotion_uses: Promotion uses
     properties: Properties
     property: Property

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -70,7 +70,22 @@ FactoryGirl.define do
             end
           end
         end
+      end
+    end
+  end
 
+  factory :completed_order_with_promotion, parent: :completed_order_with_totals, class: "Spree::Order" do
+    transient do
+      promotion nil
+      promotion_code nil
+    end
+
+    after(:create) do |order, evaluator|
+      promotion = evaluator.promotion || create(:promotion, code: "test")
+      promotion_code = evaluator.promotion_code || promotion.codes.first
+
+      promotion.actions.each do |action|
+        action.perform({order: order, promotion: promotion, promotion_code: promotion_code})
       end
     end
   end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -520,6 +520,7 @@ describe Spree::Order do
 
     it "does not attempt to process payments" do
       order.stub(:ensure_available_shipping_rates).and_return(true)
+      order.stub(:ensure_promotions_eligible).and_return(true)
       order.stub_chain(:line_items, :present?).and_return(true)
       order.stub_chain(:line_items, :map).and_return([])
       order.should_not_receive(:payment_required?)

--- a/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -26,7 +26,7 @@ describe Spree::Promotion::Actions::CreateAdjustment do
       order.shipments.create!(:cost => 10)
 
       action.perform(payload)
-      promotion.usage_count.should == 1
+      promotion.usage_count.should == 0
       order.adjustments.count.should == 1
       order.adjustments.first.amount.to_i.should == -10
     end
@@ -42,7 +42,8 @@ describe Spree::Promotion::Actions::CreateAdjustment do
 
       action.perform(payload)
       action.perform(payload)
-      promotion.usage_count.should == 1
+      promotion.usage_count.should == 0
+      order.adjustments.count.should == 1
     end
 
     context "when a promotion code is used" do

--- a/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
+++ b/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
@@ -20,7 +20,7 @@ describe Spree::Promotion::Actions::FreeShipping do
         order.shipments.first.cost.should == 100
         order.shipments.last.cost.should == 100
         action.perform(payload).should be true
-        promotion.usage_count.should == 2
+        promotion.usage_count.should == 1
         order.shipment_adjustments.count.should == 2
         order.shipment_adjustments.first.amount.to_i.should == -100
         order.shipment_adjustments.last.amount.to_i.should == -100
@@ -32,7 +32,7 @@ describe Spree::Promotion::Actions::FreeShipping do
       it "should not create a discount" do
         action.perform(payload).should be true
         action.perform(payload).should be false
-        promotion.usage_count.should == 2
+        promotion.usage_count.should == 1
         order.shipment_adjustments.count.should == 2
       end
     end

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Spree::PromotionCode do
   end
 
   describe "#usage_limit_exceeded?" do
-    subject { code.usage_limit_exceeded?(promotable) }
+    subject { code.usage_limit_exceeded? }
 
     shared_examples "it should" do
       context "when there is a usage limit" do
@@ -32,6 +32,7 @@ RSpec.describe Spree::PromotionCode do
                 :completed_order_with_promotion,
                 promotion: promotion
               )
+              code.adjustments.update_all(eligible: true)
             end
             it { is_expected.to be_truthy }
           end

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -135,4 +135,48 @@ RSpec.describe Spree::PromotionCode do
       end
     end
   end
+
+  describe "completing multiple orders with the same code", slow: true do
+    let(:promotion) do
+      FactoryGirl.create(
+        :promotion,
+        :with_order_adjustment,
+        code: "discount",
+        per_code_usage_limit: 1
+      )
+    end
+    let(:code) { promotion.codes.first }
+    let(:order) do
+      FactoryGirl.create(:order_with_line_items).tap do |order|
+        FactoryGirl.create(:payment, amount: order.total, order: order)
+        promotion.activate(order: order, promotion_code: code)
+      end
+    end
+    let(:promo_adjustment) { order.adjustments.promotion.first }
+    before do
+      order.next! until order.confirm?
+
+      FactoryGirl.create(:order_with_line_items).tap do |order|
+        FactoryGirl.create(:payment, amount: order.total, order: order)
+        promotion.activate(order: order, promotion_code: code)
+        order.next! until order.confirm?
+        order.complete!
+      end
+    end
+    it "makes the promotion ineligible" do
+      expect{
+        order.complete
+      }.to change{ promo_adjustment.reload.eligible }.to(false)
+    end
+    it "adjusts the promo_total" do
+      expect{
+        order.complete
+      }.to change(order, :promo_total).by(10)
+    end
+    it "adjusts the total" do
+      expect{
+        order.complete
+      }.to change(order, :total).by(10)
+    end
+  end
 end

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -178,5 +178,10 @@ RSpec.describe Spree::PromotionCode do
         order.complete
       }.to change(order, :total).by(10)
     end
+    it "resets the state of the order" do
+      expect{
+        order.complete
+      }.to change{ order.reload.state }.from("confirm").to("address")
+    end
   end
 end

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe Spree::PromotionCode do
           per_code_usage_limit: usage_limit
         )
       end
-      let(:promotable) { order.line_items.first }
       before do
         promotion.actions.first.perform({
           order: order,
@@ -85,10 +84,18 @@ RSpec.describe Spree::PromotionCode do
       end
       context "when there are multiple line items" do
         let(:order) { FactoryGirl.create(:order_with_line_items, line_items_count: 2) }
-        it_behaves_like "it should"
+        describe "the first item" do
+          let(:promotable) { order.line_items.first }
+          it_behaves_like "it should"
+        end
+        describe "the second item" do
+          let(:promotable) { order.line_items.last }
+          it_behaves_like "it should"
+        end
       end
       context "when there is a single line item" do
         let(:order) { FactoryGirl.create(:order_with_line_items) }
+        let(:promotable) { order.line_items.first }
         it_behaves_like "it should"
       end
     end

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -15,67 +15,60 @@ describe Spree::PromotionCode do
     end
   end
 
-  context "#usage_limit_exceeded?" do
-    subject { promotion_code.usage_limit_exceeded?(promotable) }
+  describe "#usage_limit_exceeded?" do
+    let(:promotion) { FactoryGirl.create(:promotion, :with_order_adjustment, code: "discount", per_code_usage_limit: usage_limit) }
+    let(:code) { promotion.codes.first }
 
-    let(:promotion) { create(:promotion, :with_order_adjustment, per_code_usage_limit: per_code_usage_limit) }
-    let(:promotion_code) { create(:promotion_code, promotion: promotion) }
-    let(:promotable) { create(:order) }
-    let(:order) { create(:order) }
+    let(:promotable) { FactoryGirl.create(:completed_order_with_promotion, promotion: promotion) }
 
-    context "there is a usage limit set" do
-      let!(:existing_adjustment) do
-        Spree::Adjustment.create!(label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code, adjustable: order, order: order)
+    subject { code.usage_limit_exceeded?(promotable) }
+
+    context "when there is a usage limit" do
+      context "and the limit is not exceeded" do
+        let(:usage_limit) { 10 }
+        it { is_expected.to be_falsy }
       end
-
-      context "the usage limit is not exceeded" do
-        let(:per_code_usage_limit) { 10 }
-
-        it "returns false" do
-          expect(subject).to be_falsey
+      context "and the limit is exceeded" do
+        let(:usage_limit) { 1 }
+        context "on a different order" do
+          before do
+            FactoryGirl.create(:completed_order_with_promotion, promotion: promotion)
+            promotable.adjustments.update_all(eligible: true)
+          end
+          it { is_expected.to be_truthy }
         end
-      end
-
-      context "the usage limit is exceeded" do
-        let(:per_code_usage_limit) { 1 }
-
-        context "for a different order" do
-          it "returns true" do
-            expect(subject).to be(true)
-          end
-        end
-
-        context "for the same order" do
-          let!(:existing_adjustment) do
-            Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code, order: promotable)
-          end
-
-          it "returns false" do
-            expect(subject).to be(false)
-          end
+        context "on the same order" do
+          it { is_expected.to be_falsy }
         end
       end
     end
-
-    context "there is no usage limit set" do
-      let(:per_code_usage_limit) { nil }
-
-      it "returns false" do
-        expect(subject).to be_falsey
-      end
+    context "when there is no usage limit" do
+      let(:usage_limit) { nil }
+      it { is_expected.to be_falsy }
     end
   end
 
-  context "#usage_count" do
-    let(:promotable) { create(:order) }
-    let(:promotion) { create(:promotion, :with_order_adjustment, code: 'abc123') }
-    let(:promotion_code) { promotion.codes.first }
-    let!(:adjustment1) { Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code, order: promotable) }
-    let!(:adjustment2) { Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code, order: promotable) }
+  describe "#usage_count" do
+    let(:promotion) { FactoryGirl.create(:promotion, :with_order_adjustment, code: "discount") }
+    let(:code) { promotion.codes.first }
 
-    it "counts the eligible adjustments that have used this promotion" do
-      adjustment2.update_columns(eligible: false)
-      expect(promotion_code.usage_count).to eq 1
+    subject { code.usage_count }
+
+    context "when the code is applied to a non-complete order" do
+      let(:order) { FactoryGirl.create(:order_with_line_items) }
+      before { promotion.activate(order: order, promotion_code: code) }
+      it { is_expected.to eq 0 }
+    end
+    context "when the code is applied to a complete order" do
+      context "and the promo is eligible" do
+        let!(:order) { FactoryGirl.create(:completed_order_with_promotion, promotion: promotion) }
+        it { is_expected.to eq 1 }
+      end
+      context "and the promo is ineligible" do
+        let!(:order) { FactoryGirl.create(:completed_order_with_promotion, promotion: promotion) }
+        before { order.adjustments.promotion.update_all(eligible: false) }
+        it { is_expected.to eq 0 }
+      end
     end
   end
 end

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -214,25 +214,6 @@ module Spree
                 expect(subject.error).to eq Spree.t(:coupon_code_max_usage)
               end
             end
-
-            context "when the promotion code exceeds its usage limit" do
-              let(:second_order) { create(:order, coupon_code: "10off", item_total: 50, ship_total: 10) }
-
-              before do
-                promotion.update!(per_code_usage_limit: 1)
-                Coupon.new(second_order).apply
-              end
-
-              it "is not successful" do
-                subject.apply
-                expect(subject.successful?).to be false
-              end
-
-              it "returns a coupon is at max usage error" do
-                subject.apply
-                expect(subject.error).to eq Spree.t(:coupon_code_max_usage)
-              end
-            end
           end
         end
 

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -197,7 +197,7 @@ module Spree
             end
 
             context "when the promotion exceeds its usage limit" do
-              let(:second_order) { create(:order, coupon_code: "10off", item_total: 50, ship_total: 10) }
+              let!(:second_order) { FactoryGirl.create(:completed_order_with_promotion, promotion: promotion) }
 
               before do
                 promotion.update!(usage_limit: 1)

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -338,7 +338,7 @@ describe Spree::Promotion do
     end
 
     context "when the promotion code's usage limit is exceeded" do
-      let(:order) { create(:order) }
+      let(:order) { create(:completed_order_with_totals) }
       let(:promotion) { create(:promotion, :with_order_adjustment, code: 'abc123', per_code_usage_limit: 1) }
       let(:promotion_code) { promotion.codes.first }
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -138,63 +138,121 @@ describe Spree::Promotion do
     end
   end
 
-  context "#usage_limit_exceeded?" do
-    let(:promotable) { create(:order) }
-    let(:order) { create(:order) }
+  describe "#usage_limit_exceeded?" do
+    subject { promotion.usage_limit_exceeded? }
 
-    context "there is a usage limit set" do
-      let(:promotion) { create(:promotion, :with_order_adjustment, usage_limit: usage_limit) }
-
-      let!(:existing_adjustment) do
-        Spree::Adjustment.create!(label: 'Adjustment', amount: 1, source: promotion.actions.first, adjustable: order, order: order)
+    shared_examples "it should" do
+      context "when there is a usage limit" do
+        context "and the limit is not exceeded" do
+          let(:usage_limit) { 10 }
+          it { is_expected.to be_falsy }
+        end
+        context "and the limit is exceeded" do
+          let(:usage_limit) { 1 }
+          context "on a different order" do
+            before do
+              FactoryGirl.create(
+                :completed_order_with_promotion,
+                promotion: promotion
+              )
+              promotion.actions.first.adjustments.update_all(eligible: true)
+            end
+            it { is_expected.to be_truthy }
+          end
+          context "on the same order" do
+            it { is_expected.to be_falsy }
+          end
+        end
       end
-
-      context "the usage limit is not exceeded" do
-        let(:usage_limit) { 10 }
-
-        it "returns false" do
-          expect(promotion.usage_limit_exceeded?(promotable)).to be_falsey
-        end
-      end
-
-      context "the usage limit is exceeded" do
-        let(:usage_limit) { 1 }
-
-        context "for a different order" do
-          it "returns true" do
-            expect(promotion.usage_limit_exceeded?(promotable)).to be(true)
-          end
-        end
-
-        context "for the same order" do
-          let!(:existing_adjustment) do
-            Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, order: promotable)
-          end
-
-          it "returns false" do
-            expect(promotion.usage_limit_exceeded?(promotable)).to be(false)
-          end
-        end
+      context "when there is no usage limit" do
+        let(:usage_limit) { nil }
+        it { is_expected.to be_falsy }
       end
     end
 
-    context "there is no usage limit set" do
-      it "returns false" do
-        promotion.usage_limit = nil
-        expect(promotion.usage_limit_exceeded?(promotable)).to be_falsey
+    context "with an order-level adjustment" do
+      let(:promotion) do
+        FactoryGirl.create(
+          :promotion,
+          :with_order_adjustment,
+          code: "discount",
+          usage_limit: usage_limit
+        )
+      end
+      let(:promotable) do
+        FactoryGirl.create(
+          :completed_order_with_promotion,
+          promotion: promotion
+        )
+      end
+      it_behaves_like "it should"
+    end
+
+    context "with an item-level adjustment" do
+      let(:promotion) do
+        FactoryGirl.create(
+          :promotion,
+          :with_line_item_adjustment,
+          code: "discount",
+          usage_limit: usage_limit
+        )
+      end
+      before do
+        promotion.actions.first.perform({
+          order: order,
+          promotion: promotion,
+          promotion_code: promotion.codes.first
+        })
+      end
+      context "when there are multiple line items" do
+        let(:order) { FactoryGirl.create(:order_with_line_items, line_items_count: 2) }
+        describe "the first item" do
+          let(:promotable) { order.line_items.first }
+          it_behaves_like "it should"
+        end
+        describe "the second item" do
+          let(:promotable) { order.line_items.last }
+          it_behaves_like "it should"
+        end
+      end
+      context "when there is a single line item" do
+        let(:order) { FactoryGirl.create(:order_with_line_items) }
+        let(:promotable) { order.line_items.first }
+        it_behaves_like "it should"
       end
     end
   end
 
-  context "#usage_count" do
-    let(:promotable) { create(:order) }
-    let(:promotion) { create(:promotion, :with_order_adjustment) }
-    let!(:adjustment1) { Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, order: promotable) }
-    let!(:adjustment2) { Spree::Adjustment.create!(adjustable: promotable, label: 'Adjustment', amount: 1, source: promotion.actions.first, order: promotable) }
+  describe "#usage_count" do
+    let(:promotion) do
+      FactoryGirl.create(
+        :promotion,
+        :with_order_adjustment,
+        code: "discount"
+      )
+    end
 
-    it "counts the eligible adjustments that have used this promotion" do
-      adjustment2.update_columns(eligible: false)
-      expect(promotion.usage_count).to eq 1
+    subject { promotion.usage_count }
+
+    context "when the code is applied to a non-complete order" do
+      let(:order) { FactoryGirl.create(:order_with_line_items) }
+      before { promotion.activate(order: order, promotion_code: promotion.codes.first) }
+      it { is_expected.to eq 0 }
+    end
+    context "when the code is applied to a complete order" do
+      let!(:order) do
+        FactoryGirl.create(
+          :completed_order_with_promotion,
+          promotion: promotion
+        )
+      end
+      context "and the promo is eligible" do
+        it { is_expected.to eq 1 }
+      end
+      context "and the promo is ineligible" do
+        before { order.adjustments.promotion.update_all(eligible: false) }
+        it { is_expected.to eq 0 }
+      end
     end
   end
 
@@ -299,7 +357,7 @@ describe Spree::Promotion do
 
     it "counts eligible adjustments" do
       adjustment.update_column(:eligible, true)
-      expect(promotion.usage_count).to eq(1)
+      expect(promotion.usage_count).to eq(0)
     end
 
     # Regression test for #4112
@@ -324,11 +382,14 @@ describe Spree::Promotion do
     end
 
     context "when the promotion's usage limit is exceeded" do
-      let(:order) { create(:order) }
-      let(:promotion) { create(:promotion, :with_order_adjustment) }
+      let(:order) { FactoryGirl.create(:completed_order_with_promotion, promotion: promotion) }
+      let(:promotion) { FactoryGirl.create(:promotion, :with_order_adjustment) }
 
       before do
-        Spree::Adjustment.create!(label: 'Adjustment', amount: 1, source: promotion.actions.first, adjustable: order, order: order)
+        FactoryGirl.create(
+          :completed_order_with_promotion,
+          promotion: promotion
+        )
         promotion.usage_limit = 1
       end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -338,12 +338,16 @@ describe Spree::Promotion do
     end
 
     context "when the promotion code's usage limit is exceeded" do
-      let(:order) { create(:completed_order_with_totals) }
+      let(:order) { FactoryGirl.create(:completed_order_with_promotion, promotion: promotion) }
       let(:promotion) { create(:promotion, :with_order_adjustment, code: 'abc123', per_code_usage_limit: 1) }
       let(:promotion_code) { promotion.codes.first }
 
       before do
-        Spree::Adjustment.create!(label: 'Adjustment', amount: 1, source: promotion.actions.first, promotion_code: promotion_code, order: order, adjustable: order)
+        FactoryGirl.create(
+          :completed_order_with_promotion,
+          promotion: promotion
+        )
+        promotion_code.adjustments.update_all(eligible: true)
       end
 
       it "returns false" do

--- a/frontend/spec/features/promotion_code_invalidation_spec.rb
+++ b/frontend/spec/features/promotion_code_invalidation_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.feature "Promotion Code Invalidation" do
+  given!(:promotion) do
+    FactoryGirl.create(
+      :promotion_with_item_adjustment,
+      code: "PROMO",
+      per_code_usage_limit: 1,
+      adjustment_rate: 5
+    )
+  end
+
+  background do
+    FactoryGirl.create(:product, name: "DL-44")
+    FactoryGirl.create(:product, name: "E-11")
+
+    visit spree.root_path
+    click_link "DL-44"
+    click_button "Add To Cart"
+
+    visit spree.root_path
+    click_link "E-11"
+    click_button "Add To Cart"
+  end
+
+  scenario "adding the promotion to a cart with two applicable items" do
+    fill_in "Coupon code", with: "PROMO"
+    click_button "Update"
+
+    expect(page).to have_content("The coupon code was successfully applied to your order")
+
+    within("#cart_adjustments") do
+      expect(page).to have_content("-$10.00")
+    end
+  end
+end

--- a/frontend/spec/features/promotion_code_invalidation_spec.rb
+++ b/frontend/spec/features/promotion_code_invalidation_spec.rb
@@ -32,5 +32,20 @@ RSpec.feature "Promotion Code Invalidation" do
     within("#cart_adjustments") do
       expect(page).to have_content("-$10.00")
     end
+
+    # Remove an item
+    fill_in "order_line_items_attributes_0_quantity", with: 0
+    click_button "Update"
+    within("#cart_adjustments") do
+      expect(page).to have_content("-$5.00")
+    end
+
+    # Add it back
+    visit spree.root_path
+    click_link "DL-44"
+    click_button "Add To Cart"
+    within("#cart_adjustments") do
+      expect(page).to have_content("-$10.00")
+    end
   end
 end


### PR DESCRIPTION
Simply updates promotion codes to only consider themselves used when associated to a completed order. This means that a user can add the same code to multiple carts. It isn't until the code is associated to a completed order that it's considered used.