### PR TITLE
Allow specifying a custom config/database.yml for specs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,8 @@ set_gemfile(){
   export BUNDLE_GEMFILE="`pwd`/Gemfile"
 }
 
-# Target postgres. Override with: `DB=sqlite bash build.sh`
+# Target postgres. Override with: `DB=sqlite bash build.sh` (or DB=mysql)
+# You can also supply DB_TEMPLATE for a fully custom database.yml.
 export DB=${DB:-postgres}
 
 # Spree defaults

--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -41,7 +41,11 @@ module Spree
       @lib_name = options[:lib_name]
       @database = options[:database]
 
-      template "rails/database.yml", "#{dummy_path}/config/database.yml", :force => true
+      if ENV['DB_TEMPLATE']
+        template ENV['DB_TEMPLATE'], "#{dummy_path}/config/database.yml", :force => true
+      else
+        template "rails/database.yml", "#{dummy_path}/config/database.yml", :force => true
+      end
       template "rails/boot.rb", "#{dummy_path}/config/boot.rb", :force => true
       template "rails/application.rb", "#{dummy_path}/config/application.rb", :force => true
       template "rails/routes.rb", "#{dummy_path}/config/routes.rb", :force => true


### PR DESCRIPTION
e.g. for specs running on continuous integration tools.