### PR TITLE
Show carton external_number in admin

### DIFF
--- a/backend/app/views/spree/admin/orders/_carton.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton.html.erb
@@ -27,7 +27,7 @@
       <th><%= Spree.t(:total) %></th>
     </thead>
 
-    <tbody data-shipment-number="<%= carton.number %>" data-order-number="<%= order.number %>">
+    <tbody data-hook="carton-details" data-shipment-number="<%= carton.number %>" data-order-number="<%= order.number %>">
       <%= render 'spree/admin/orders/carton_manifest', carton: carton, order: order %>
 
       <tr class="show-method total">
@@ -78,6 +78,12 @@
               <%= link_to order.number, edit_admin_order_path(order) %>
             <% end %>
           </td>
+        </tr>
+      <% end %>
+
+      <% if carton.external_number.present? %>
+        <tr class="external-number">
+          <strong><%= Spree.t(:carton_external_number) %>:&nbsp;</strong><%= carton.external_number %>
         </tr>
       <% end %>
     </tbody>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -513,6 +513,7 @@ en:
     cart_subtotal:
       one: 'Subtotal (1 item)'
       other: 'Subtotal (%{count} items)'
+    carton_external_number: External Number
     carton_orders: 'Other orders with Carton'
     categories: Categories
     category: Category


### PR DESCRIPTION
External number is e.g. a 3PL idenitifier number.
Also add a data-hook for the carton details.