### PR TITLE
Carton capture

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -35,7 +35,12 @@ module Spree
     preference :alternative_billing_phone, :boolean, default: false # Request extra phone for bill addr
     preference :alternative_shipping_phone, :boolean, default: false # Request extra phone for ship addr
     preference :always_put_site_name_in_title, :boolean, default: true
+
+    # TODO: Probably replace auto_capture, auto_capture_at_ship with a single enum.
+    # eq: auto_capture_mode: ['manual', 'order-completion', 'shipping']
     preference :auto_capture, :boolean, default: false # automatically capture the credit card (as opposed to just authorize and capture later)
+    preference :auto_capture_at_ship, :boolean, default: false # Captures payment when inventory units are shipped
+
     preference :binary_inventory_cache, :boolean, default: false # only invalidate product cache when a stock item changes whether it is in_stock
     preference :checkout_zone, :string, default: nil # replace with the name of a zone if you would like to limit the countries
     preference :company, :boolean, default: false # Request company field for billing and shipping addr

--- a/core/app/models/spree/carton.rb
+++ b/core/app/models/spree/carton.rb
@@ -6,6 +6,7 @@ class Spree::Carton < ActiveRecord::Base
   has_many :inventory_units, inverse_of: :carton
   has_many :orders, -> { uniq }, through: :inventory_units
   has_many :shipments, -> { uniq }, through: :inventory_units
+  has_many :carton_captures, inverse_of: :carton
 
   validates :address, presence: true
   validates :stock_location, presence: true

--- a/core/app/models/spree/carton.rb
+++ b/core/app/models/spree/carton.rb
@@ -6,7 +6,7 @@ class Spree::Carton < ActiveRecord::Base
   has_many :inventory_units, inverse_of: :carton
   has_many :orders, -> { uniq }, through: :inventory_units
   has_many :shipments, -> { uniq }, through: :inventory_units
-  has_many :carton_captures, inverse_of: :carton
+  has_many :carton_captures, -> { uniq }, through: :inventory_units
 
   validates :address, presence: true
   validates :stock_location, presence: true

--- a/core/app/models/spree/carton_capture.rb
+++ b/core/app/models/spree/carton_capture.rb
@@ -1,0 +1,10 @@
+class Spree::CartonCapture < ActiveRecord::Base
+  has_many :inventory_unit_captures, inverse_of: :carton_capture
+  has_many :inventory_units, through: :inventory_unit_captures
+  has_many :cartons, -> { uniq }, through: :inventory_units
+
+  has_many :carton_capture_payment_capture_events
+  has_many :payment_capture_events, through: :carton_capture_payment_capture_events
+
+  validates :captured_at, presence: true
+end

--- a/core/app/models/spree/carton_capture.rb
+++ b/core/app/models/spree/carton_capture.rb
@@ -2,9 +2,16 @@ class Spree::CartonCapture < ActiveRecord::Base
   has_many :inventory_unit_captures, inverse_of: :carton_capture
   has_many :inventory_units, through: :inventory_unit_captures
   has_many :cartons, -> { uniq }, through: :inventory_units
+  has_many :orders, -> { uniq }, through: :inventory_units
 
   has_many :carton_capture_payment_capture_events
   has_many :payment_capture_events, through: :carton_capture_payment_capture_events
 
   validates :captured_at, presence: true
+
+  def total(inventory_unit_captures = self.inventory_unit_captures)
+    inventory_unit_captures.to_a.sum do |capture|
+      capture.price + capture.promo_total + capture.additional_tax_total + capture.order_adjustment_total
+    end.to_d
+  end
 end

--- a/core/app/models/spree/carton_capture_payment_capture_event.rb
+++ b/core/app/models/spree/carton_capture_payment_capture_event.rb
@@ -1,0 +1,7 @@
+class Spree::CartonCapturePaymentCaptureEvent < ActiveRecord::Base
+  belongs_to :carton_capture, class_name: 'Spree::CartonCapture'
+  belongs_to :payment_capture_event, class_name: 'Spree::PaymentCaptureEvent'
+
+  validates :carton_capture, presence: true
+  validates :payment_capture_event, presence: true
+end

--- a/core/app/models/spree/carton_capturing.rb
+++ b/core/app/models/spree/carton_capturing.rb
@@ -1,0 +1,52 @@
+class Spree::CartonCapturing
+  class CaptureTooLargeError < StandardError; end
+
+  class_attribute :carton_payments_strategy_class
+  self.carton_payments_strategy_class = Spree::CartonPaymentStrategy
+
+  def initialize(carton)
+    @carton = carton
+  end
+
+  def capture
+    carton_capture = Spree::CartonCapture.new(captured_at: Time.now)
+
+    carton_inventory_units_by_order = @carton.inventory_units.includes(
+      line_item: {inventory_units: :inventory_unit_capture}
+    ).group_by(&:order)
+
+    carton_inventory_units_by_order.each do |order, order_inventory_units|
+      build_order_unit_captures(
+        carton_capture: carton_capture,
+        order: order,
+        inventory_units: order_inventory_units,
+      )
+    end
+
+    carton_payments_strategy_class.new(carton_capture).capture_payments
+    carton_capture.save!
+    carton_capture
+  end
+
+  private
+
+  def build_order_unit_captures(carton_capture:, order:, inventory_units:)
+    inventory_units.each do |inventory_unit|
+      calculator = Spree::UnprocessedInventoryUnitAmountCalculator.new(inventory_unit)
+
+      carton_capture.inventory_unit_captures.build(
+        inventory_unit: inventory_unit,
+        currency: calculator.currency,
+        price: calculator.price_total,
+        promo_total: calculator.promotion_total,
+        additional_tax_total: calculator.additional_tax_total,
+        included_tax_total: calculator.included_tax_total,
+        order_adjustment_total: calculator.order_adjustment_total,
+      )
+    end
+
+    if carton_capture.total > order.total
+      raise CaptureTooLargeError, "Total capture amount is larger than order total"
+    end
+  end
+end

--- a/core/app/models/spree/carton_payment_strategy.rb
+++ b/core/app/models/spree/carton_payment_strategy.rb
@@ -1,0 +1,34 @@
+class Spree::CartonPaymentStrategy
+  class_attribute :eligible_payments
+  self.eligible_payments = []
+
+  def initialize(carton_capture)
+    @carton_capture = carton_capture
+  end
+
+  def capture_payments
+    order_unit_capture_groups.each do |order, unit_captures|
+      uncaptured_amount = @carton_capture.total(unit_captures)
+
+      Spree::OrderMutex.with_lock!(order) do
+        while uncaptured_amount > 0 do
+          payment = sorted_eligible_payments(order).shift
+          amount = [uncaptured_amount, payment.uncaptured_amount].min
+          payment.capture!((amount * 100).to_i)
+          uncaptured_amount -= amount
+        end
+      end
+    end
+  end
+
+  private
+
+  def sorted_eligible_payments(order)
+    payments = order.pending_payments
+    payments = payments.sort_by { |p| [eligible_payments.index(p.payment_method.class), p.id] }
+  end
+
+  def order_unit_capture_groups
+    @carton_capture.inventory_unit_captures.group_by{|iuc| iuc.inventory_unit.order }
+  end
+end

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -13,6 +13,8 @@ module Spree
     has_many :return_items, inverse_of: :inventory_unit, dependent: :destroy
     has_one :original_return_item, class_name: "Spree::ReturnItem", foreign_key: :exchange_inventory_unit_id, dependent: :destroy
     has_one :inventory_unit_capture, inverse_of: :inventory_unit
+    has_one :carton_capture, through: :inventory_unit_capture
+    has_one :unit_cancel, inverse_of: :inventory_unit
 
     scope :backordered, -> { where state: 'backordered' }
     scope :on_hand, -> { where state: 'on_hand' }

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -12,6 +12,7 @@ module Spree
 
     has_many :return_items, inverse_of: :inventory_unit, dependent: :destroy
     has_one :original_return_item, class_name: "Spree::ReturnItem", foreign_key: :exchange_inventory_unit_id, dependent: :destroy
+    has_one :inventory_unit_capture, inverse_of: :inventory_unit
 
     scope :backordered, -> { where state: 'backordered' }
     scope :on_hand, -> { where state: 'on_hand' }

--- a/core/app/models/spree/inventory_unit_capture.rb
+++ b/core/app/models/spree/inventory_unit_capture.rb
@@ -1,0 +1,7 @@
+class Spree::InventoryUnitCapture < ActiveRecord::Base
+  belongs_to :inventory_unit, class_name: 'Spree::InventoryUnit', inverse_of: :inventory_unit_capture
+  belongs_to :carton_capture, class_name: 'Spree::CartonCapture', inverse_of: :inventory_unit_captures
+
+  validates :inventory_unit, presence: true
+  validates :carton_capture, presence: true
+end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -11,6 +11,7 @@ module Spree
 
     has_many :adjustments, as: :adjustable, dependent: :destroy
     has_many :inventory_units, inverse_of: :line_item
+    has_many :inventory_unit_captures, through: :inventory_units
 
     before_validation :copy_price
     before_validation :copy_tax_category

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -70,6 +70,7 @@ module Spree
         pluck(:state).uniq
       end
     end
+    has_many :inventory_unit_captures, through: :line_items
 
     accepts_nested_attributes_for :line_items
     accepts_nested_attributes_for :bill_address

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -18,14 +18,23 @@ class Spree::OrderCancellations
   private
 
   def short_ship_unit(inventory_unit, whodunnit:nil)
+    calculator = Spree::UnprocessedInventoryUnitAmountCalculator.new(inventory_unit)
+
     Spree::InventoryUnit.transaction do
       unit_cancel = Spree::UnitCancel.create!(
         inventory_unit: inventory_unit,
+        price: calculator.price_total,
+        promo_total: calculator.promotion_total,
+        additional_tax_total: calculator.additional_tax_total,
+        included_tax_total: calculator.included_tax_total,
+        order_adjustment_total: calculator.order_adjustment_total,
         reason: Spree::UnitCancel::SHORT_SHIP,
         created_by: whodunnit,
       )
+
       unit_cancel.adjust!
       inventory_unit.cancel!
+      return unit_cancel
     end
   end
 end

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -71,6 +71,7 @@ class Spree::OrderShipping
       end
     end
 
+    Spree::CartonCapturing.new(carton).capture if Spree::Config[:auto_capture_at_ship]
     send_shipment_email(carton) if stock_location.fulfillable? # e.g. digital gift cards that aren't actually shipped
     fulfill_order_stock_locations(stock_location)
     update_order_state

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -33,6 +33,7 @@ module Spree
     scope :offset_payment, -> { where("source_type = 'Spree::Payment' AND amount < 0 AND state = 'completed'") }
     scope :completed, -> { with_state('completed') }
     scope :pending, -> { with_state('pending') }
+    scope :processing, -> { with_state('processing') }
     scope :failed, -> { with_state('failed') }
     scope :valid, -> { where.not(state: %w(failed invalid)) }
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -151,8 +151,26 @@ module Spree
       return true
     end
 
+    def captured_amount
+      capture_events.sum(:amount)
+    end
+
     def uncaptured_amount
-      amount - capture_events.sum(:amount)
+      amount - captured_amount
+    end
+
+    def split_uncaptured_amount
+      if uncaptured_amount > 0
+        order.payments.create! amount: uncaptured_amount,
+                               avs_response: avs_response,
+                               cvv_response_code: cvv_response_code,
+                               cvv_response_message: cvv_response_message,
+                               payment_method: payment_method,
+                               response_code: response_code,
+                               source: source,
+                               state: 'pending'
+        update_attributes(amount: captured_amount)
+      end
     end
 
     private

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -38,8 +38,8 @@ module Spree
       # Takes the amount in cents to capture.
       # Can be used to capture partial amounts of a payment.
       def capture!(amount=nil)
-        amount ||= money.money.cents
         return true if completed?
+        amount ||= money.money.cents
         started_processing!
         protect_from_connection_error do
           check_environment
@@ -52,6 +52,7 @@ module Spree
 
           money = ::Money.new(amount, Spree::Config[:currency])
           capture_events.create!(amount: money.to_f)
+          split_uncaptured_amount
           handle_response(response, :complete, :failure)
         end
       end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -13,6 +13,8 @@ module Spree
     has_many :adjustments, as: :adjustable, dependent: :delete_all
     has_many :cartons, -> { uniq }, through: :inventory_units
 
+    has_one :shipment_capture, inverse_of: :shipment
+
     after_save :update_adjustments
 
     before_validation :set_cost_zero_when_nil

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -221,7 +221,7 @@ module Spree
       return 'pending' unless order.can_ship?
       return 'pending' if inventory_units.any? &:backordered?
       return 'shipped' if state == 'shipped'
-      order.paid? ? 'ready' : 'pending'
+      order.paid? || Spree::Config[:auto_capture_at_ship] ? 'ready' : 'pending'
     end
 
     def tracking_url

--- a/core/app/models/spree/shipment_capture.rb
+++ b/core/app/models/spree/shipment_capture.rb
@@ -1,0 +1,9 @@
+class Spree::ShipmentCapture < ActiveRecord::Base
+  belongs_to :shipment, class_name: 'Spree::Shipment', inverse_of: :shipment_capture
+
+  has_many :shipment_capture_payment_capture_events
+  has_many :payment_capture_events, through: :shipment_capture_payment_capture_events
+
+  validates :shipment, presence: true
+  validates :captured_at, presence: true
+end

--- a/core/app/models/spree/shipment_capture_payment_capture_event.rb
+++ b/core/app/models/spree/shipment_capture_payment_capture_event.rb
@@ -1,0 +1,7 @@
+class Spree::ShipmentCapturePaymentCaptureEvent < ActiveRecord::Base
+  belongs_to :shipment_capture, class_name: 'Spree::ShipmentCapture'
+  belongs_to :payment_capture_event, class_name: 'Spree::PaymentCaptureEvent'
+
+  validates :shipment_capture, presence: true
+  validates :payment_capture_event, presence: true
+end

--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -27,6 +27,6 @@ class Spree::UnitCancel < ActiveRecord::Base
   # This method is used by Adjustment#update to recalculate the cost.
   def compute_amount(line_item)
     raise "Adjustable does not match line item" unless line_item == inventory_unit.line_item
-    -(price + promo_total + additional_tax_total + included_tax_total + order_adjustment_total)
+    -(price + promo_total + additional_tax_total + order_adjustment_total)
   end
 end

--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -3,7 +3,7 @@
 # This class should encapsulate logic related to canceling inventory after order complete
 class Spree::UnitCancel < ActiveRecord::Base
   SHORT_SHIP = 'Short Ship'
-  belongs_to :inventory_unit
+  belongs_to :inventory_unit, inverse_of: :unit_cancel
   has_one :adjustment, as: :source, dependent: :destroy
 
   validates :inventory_unit, presence: true
@@ -27,6 +27,6 @@ class Spree::UnitCancel < ActiveRecord::Base
   # This method is used by Adjustment#update to recalculate the cost.
   def compute_amount(line_item)
     raise "Adjustable does not match line item" unless line_item == inventory_unit.line_item
-    -(line_item.total.to_d / line_item.inventory_units.not_canceled.reject(&:original_return_item ).size)
+    -(price + promo_total + additional_tax_total + included_tax_total + order_adjustment_total)
   end
 end

--- a/core/app/models/spree/unprocessed_inventory_unit_amount_calculator.rb
+++ b/core/app/models/spree/unprocessed_inventory_unit_amount_calculator.rb
@@ -1,0 +1,67 @@
+class Spree::UnprocessedInventoryUnitAmountCalculator
+  class InventoryPreviouslyProcessedError < StandardError; end
+
+  def initialize(inventory_unit)
+    @inventory_unit = inventory_unit
+
+    raise InventoryPreviouslyProcessedError if previously_processed?
+
+    @line_item = inventory_unit.line_item
+    @order = inventory_unit.order
+    inventory_units = @line_item.inventory_units.reject(&:original_return_item)
+
+    captured, uncaptured = inventory_units.partition(&:inventory_unit_capture)
+    canceled, @unprocessed = uncaptured.partition(&:unit_cancel)
+
+    @cancels = canceled.map(&:unit_cancel)
+    @captures = captured.map(&:inventory_unit_capture)
+  end
+
+  def price_total
+    @line_item.price
+  end
+
+  def promotion_total
+    amount_to_process(
+      total: @line_item.promo_total,
+      processed_amount: @captures.sum(&:promo_total) + @cancels.sum(&:promo_total),
+    )
+  end
+
+  def additional_tax_total
+    amount_to_process(
+      total: @line_item.additional_tax_total,
+      processed_amount: @captures.sum(&:additional_tax_total) + @cancels.sum(&:additional_tax_total),
+    )
+  end
+
+  def included_tax_total
+    amount_to_process(
+      total: @line_item.included_tax_total,
+      processed_amount: @captures.sum(&:included_tax_total) + @cancels.sum(&:included_tax_total),
+    )
+  end
+
+  def order_adjustment_total
+    amount_to_process(
+      total: @order.adjustments.eligible.sum(:amount),
+      processed_amount: @captures.sum(&:order_adjustment_total) + @cancels.sum(&:order_adjustment_total),
+    )
+  end
+
+  def currency
+    @line_item.currency
+  end
+
+  private
+
+  def amount_to_process(total:, processed_amount:)
+    unprocessed_amount = total - processed_amount
+    (unprocessed_amount / @unprocessed.count).round(2)
+  end
+
+  def previously_processed?
+    @inventory_unit.inventory_unit_capture.present? ||
+      @inventory_unit.unit_cancel.present?
+  end
+end

--- a/core/db/migrate/20150424112039_carton_capture_models.rb
+++ b/core/db/migrate/20150424112039_carton_capture_models.rb
@@ -1,0 +1,80 @@
+class CartonCaptureModels < ActiveRecord::Migration
+  def change
+    create_table :spree_carton_captures do |t|
+      t.datetime :captured_at
+
+      t.timestamps
+    end
+
+    create_table :spree_shipment_captures do |t|
+      t.references :shipment, index: true, unique: true
+      t.datetime :captured_at
+
+      t.decimal :cost,                 precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :promo_total,          precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :additional_tax_total, precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :included_tax_total,   precision: 10, scale: 2, default: 0.0, null: false
+
+      t.timestamps
+    end
+
+    create_table :spree_inventory_unit_captures do |t|
+      t.references :inventory_unit, index: true, unique: true
+      t.references :carton_capture, index: true
+
+      t.string :currency
+      t.decimal :price,                  precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :promo_total,            precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :additional_tax_total,   precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :included_tax_total,     precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :order_adjustment_total, precision: 10, scale: 2, default: 0.0, null: false
+
+      t.timestamps
+    end
+
+    create_table :spree_carton_capture_payment_capture_events do |t|
+      t.references :carton_capture
+      t.references :payment_capture_event
+
+      t.timestamps
+    end
+
+    create_table :spree_shipment_capture_payment_capture_events do |t|
+      t.references :shipment_capture
+      t.references :payment_capture_event
+
+      t.timestamps
+    end
+
+    change_table :spree_unit_cancels do |t|
+      t.string :currency
+      t.decimal :price,                  precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :promo_total,            precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :additional_tax_total,   precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :included_tax_total,     precision: 10, scale: 2, default: 0.0, null: false
+      t.decimal :order_adjustment_total, precision: 10, scale: 2, default: 0.0, null: false
+    end
+
+    # The default index names for these are too long for sqlite/mysql/postgres
+    add_index(
+      :spree_carton_capture_payment_capture_events,
+      :carton_capture_id,
+      name: 'index_spree_carton_payment_captures_on_carton_capture_id',
+    )
+    add_index(
+      :spree_carton_capture_payment_capture_events,
+      :payment_capture_event_id,
+      name: 'index_spree_carton_payment_captures_on_payment_capture_id',
+    )
+    add_index(
+      :spree_shipment_capture_payment_capture_events,
+      :shipment_capture_id,
+      name: 'index_spree_shipment_payment_captures_on_carton_capture_id',
+    )
+    add_index(
+      :spree_carton_capture_payment_capture_events,
+      :payment_capture_event_id,
+      name: 'index_spree_shipment_payment_captures_on_payment_capture_id',
+    )
+  end
+end

--- a/core/lib/spree/testing_support/factories/carton_capture_factory.rb
+++ b/core/lib/spree/testing_support/factories/carton_capture_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :carton_capture, class: Spree::CartonCapture do
+    captured_at { Time.now }
+  end
+end

--- a/core/lib/spree/testing_support/factories/inventory_unit_capture_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_capture_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :inventory_unit_capture, class: Spree::InventoryUnitCapture do
+    inventory_unit
+    carton_capture
+  end
+end

--- a/core/lib/spree/testing_support/factories/shipment_capture_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_capture_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :shipment_capture, class: Spree::ShipmentCapture do
+    shipment
+    captured_at { Time.now }
+  end
+end

--- a/core/spec/models/spree/carton_capture_spec.rb
+++ b/core/spec/models/spree/carton_capture_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Spree::CartonCapture do
+  describe 'creation' do
+    it do
+      expect {
+        create(:carton_capture)
+      }.to_not raise_error
+    end
+  end
+end

--- a/core/spec/models/spree/carton_capture_spec.rb
+++ b/core/spec/models/spree/carton_capture_spec.rb
@@ -1,11 +1,25 @@
 require 'spec_helper'
 
 describe Spree::CartonCapture do
-  describe 'creation' do
-    it do
-      expect {
-        create(:carton_capture)
-      }.to_not raise_error
+  describe '#total' do
+    subject { carton_capture.total }
+    let(:carton_capture) { create(:carton_capture) }
+
+    before do
+      2.times do
+        create(:inventory_unit_capture,
+          carton_capture: carton_capture,
+          price: 1.1,
+          promo_total: 2.2,
+          included_tax_total: 3.3,
+          additional_tax_total: 4.4,
+          order_adjustment_total: 5.5,
+        )
+      end
+    end
+
+    it "sums it's inventory unit captures breakdown totals" do
+      expect(subject).to eq 33.0
     end
   end
 end

--- a/core/spec/models/spree/carton_capture_spec.rb
+++ b/core/spec/models/spree/carton_capture_spec.rb
@@ -19,7 +19,7 @@ describe Spree::CartonCapture do
     end
 
     it "sums it's inventory unit captures breakdown totals" do
-      expect(subject).to eq 33.0
+      expect(subject).to eq 26.4
     end
   end
 end

--- a/core/spec/models/spree/carton_capturing_spec.rb
+++ b/core/spec/models/spree/carton_capturing_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+
+describe Spree::CartonCapturing do
+  let(:carton_capturing) { Spree::CartonCapturing.new(carton) }
+  let(:order) { create(:order_with_line_items) }
+  let(:carton) { Spree::OrderShipping.new(order).ship_shipment(order.shipments.first) }
+  let(:shipment) { order.shipments.first }
+
+  describe "#capture" do
+    subject { carton_capturing.capture }
+
+    context "a simple order" do
+      it "creates a carton capture" do
+        expect { subject }.to change { Spree::CartonCapture.count }.by(1)
+      end
+
+      it "creates a inventory unit capture with the correct amounts" do
+        expect { subject }.to change { Spree::InventoryUnitCapture.count }.by(1)
+
+        capture = Spree::InventoryUnitCapture.last
+        expect(capture.carton_capture).to eq Spree::CartonCapture.last
+        expect(capture.price).to eq 10
+        expect(capture.currency).to eq 'USD'
+        expect(capture.promo_total).to eq 0
+        expect(capture.additional_tax_total).to eq 0
+        expect(capture.included_tax_total).to eq 0
+        expect(capture.order_adjustment_total).to eq 0
+      end
+    end
+
+    context "when there are multiple captures" do
+      let!(:promotion) { create(:promotion_with_item_adjustment, adjustment_rate: 1.66, code: 'PROMO') }
+      let(:inventory_unit2) { order.inventory_units[1] }
+      let(:inventory_unit3) { order.inventory_units[2] }
+      let(:carton_captures) { order.cartons.flat_map(&:carton_captures) }
+
+      let(:carton2) do
+        Spree::OrderShipping.new(order).ship(
+          inventory_units: [inventory_unit2],
+          stock_location: shipment.stock_location,
+          address: shipment.address,
+          shipping_method: shipment.shipping_method,
+          shipped_at: Time.now,
+        )
+      end
+
+      let(:carton3) do
+        Spree::OrderShipping.new(order).ship(
+          inventory_units: [inventory_unit3],
+          stock_location: shipment.stock_location,
+          address: shipment.address,
+          shipping_method: shipment.shipping_method,
+          shipped_at: Time.now,
+        )
+      end
+
+      let!(:order) { create(:order, ship_address: create(:address)) }
+      let!(:product) { create(:product, price: 10.00) }
+      let!(:variant) do
+        create(:variant, price: 10, product: product, track_inventory: false, tax_category: tax_rate.tax_category)
+      end
+      let!(:shipping_method) { create(:free_shipping_method) }
+      let(:tax_rate) { create(:tax_rate, amount: 0.1, zone: create(:global_zone, name: "Some Tax Zone")) }
+
+      before do
+        order.contents.add(variant, 3)
+        order.contents.apply_coupon_code('PROMO')
+        Spree::Adjustment.create!(order: order, adjustable: order, label: 'Some Label', amount: -1.66)
+        order.contents.advance
+        create(:payment, order: order, amount: order.total)
+        order.complete!
+        order.reload
+        Spree::CartonCapturing.new(carton2).capture
+        Spree::CartonCapturing.new(carton3).capture
+      end
+
+      it "the carton capture totals equal the order total" do
+        subject
+        expect(carton_captures.sum(&:total)).to eq order.total
+      end
+
+      context "the inventory unit capture totals" do
+        let(:inventory_captures) { carton_captures.flat_map(&:inventory_unit_captures) }
+
+        before { subject }
+
+        it "has the correct price breakdown" do
+          expect(inventory_captures.map(&:price)).to match_array([10.0, 10.0, 10.0])
+        end
+
+        it "has the correct promo breakdown" do
+          expect(inventory_captures.map(&:promo_total)).to match_array([-0.55, -0.55, -0.56].map(&:to_d))
+        end
+
+        it "has the correct additional tax breakdown" do
+          expect(inventory_captures.map(&:additional_tax_total)).to match_array([0.94, 0.94, 0.95].map(&:to_d))
+        end
+
+        it "has the correct included tax breakdown" do
+          expect(inventory_captures.map(&:included_tax_total)).to match_array([0.0, 0.0, 0.0])
+        end
+
+        it "has the correct order adjustment breakdown" do
+          expect(inventory_captures.map(&:order_adjustment_total)).to match_array([-0.55, -0.55, -0.56].map(&:to_d))
+        end
+      end
+
+      context "the payment capture totals" do
+        before { subject }
+        let(:capture_events) { order.payments.flat_map(&:capture_events) }
+
+        it "has three payment captures" do
+          expect(capture_events.size).to eq 3
+        end
+
+        it "fully charges the order" do
+          expect(capture_events.sum(&:amount)).to eq(order.total)
+        end
+      end
+    end
+
+    context "when we are trying to charge too much" do
+      before do
+        allow_any_instance_of(Spree::UnprocessedInventoryUnitAmountCalculator).to receive(:price_total).and_return(order.total + 1)
+      end
+
+      it "raises an error and does not create any captures" do
+        expect {
+          expect {
+            expect { subject }.to raise_error(Spree::CartonCapturing::CaptureTooLargeError)
+          }.to_not change { Spree::InventoryUnitCapture.count }
+        }.to_not change { Spree::CartonCapture.count }
+      end
+    end
+
+  end
+end

--- a/core/spec/models/spree/inventory_unit_capture_spec.rb
+++ b/core/spec/models/spree/inventory_unit_capture_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Spree::InventoryUnitCapture do
+  describe 'creation' do
+    it do
+      expect {
+        create(:inventory_unit_capture)
+      }.to_not raise_error
+    end
+  end
+end

--- a/core/spec/models/spree/shipment_capture_spec.rb
+++ b/core/spec/models/spree/shipment_capture_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Spree::ShipmentCapture do
+  describe 'creation' do
+    it do
+      expect {
+        create(:shipment_capture)
+      }.to_not raise_error
+    end
+  end
+end

--- a/core/spec/models/spree/unit_cancel_spec.rb
+++ b/core/spec/models/spree/unit_cancel_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 
 describe Spree::UnitCancel do
-  let(:unit_cancel) { Spree::UnitCancel.create!(inventory_unit: inventory_unit, reason: Spree::UnitCancel::SHORT_SHIP) }
   let(:inventory_unit) { create(:inventory_unit) }
 
   describe '#adjust!' do
     subject { unit_cancel.adjust! }
+
+    let(:unit_cancel) { Spree::UnitCancel.create!(inventory_unit: inventory_unit, reason: Spree::UnitCancel::SHORT_SHIP, price: 10.0) }
 
     it "creates an adjustment with the correct attributes" do
       expect { subject }.to change{ Spree::Adjustment.count }.by(1)
@@ -33,19 +34,20 @@ describe Spree::UnitCancel do
 
     let(:line_item) { inventory_unit.line_item }
     let!(:inventory_unit2) { create(:inventory_unit, line_item: inventory_unit.line_item) }
-
-    context "all inventory on the line item are not canceled" do
-      it "divides the line item total by the inventory units size" do
-        expect(subject).to eq -5.0
-      end
+    let(:unit_cancel) do
+      Spree::UnitCancel.create!(
+        inventory_unit: inventory_unit,
+        reason: Spree::UnitCancel::SHORT_SHIP,
+        price: 10.0,
+        promo_total: 1.1,
+        additional_tax_total: 2.2,
+        included_tax_total: 3.3,
+        order_adjustment_total: 4.4,
+      )
     end
 
-    context "some inventory on the line item is canceled" do
-      before { inventory_unit2.cancel! }
-
-      it "divides the line item total by the uncanceled units size" do
-        expect(subject).to eq -10.0
-      end
+    it "sums all unit cancel's the breakdown totals" do
+      expect(subject).to eq -17.7
     end
 
     context "it is called with a line item that doesnt belong to the inventory unit" do
@@ -53,93 +55,6 @@ describe Spree::UnitCancel do
 
       it "raises an error" do
         expect { subject }.to raise_error
-      end
-    end
-
-    context "when exchanges are present" do
-      let!(:order) { create(:order, ship_address: create(:address)) }
-      let!(:product) { create(:product, price: 10.00) }
-      let!(:variant) do
-        create(:variant, price: 10, product: product, track_inventory: false)
-      end
-      let!(:shipping_method) { create(:free_shipping_method) }
-      let(:exchange_variant) do
-        create(:variant, product: variant.product, price: 10, track_inventory: false)
-      end
-
-      before do
-        @old_expedited_exchanges_value = Spree::Config[:expedited_exchanges]
-        Spree::Config[:expedited_exchanges] = true
-      end
-      after do
-        Spree::Config[:expedited_exchanges] = @old_expedited_exchanges_value
-      end
-
-      # This sets up an order with one shipped inventory unit, one unshipped
-      # inventory unit, and one unshipped exchange inventory unit.
-      before do
-        # Complete an order with 1 line item with quantity=2
-        order.contents.add(variant, 2)
-        order.contents.advance
-        create(:payment, order: order, amount: order.total)
-        order.complete!
-        order.reload
-
-        # Ship _one_ of the inventory units
-        @shipment = order.shipments.first
-        @shipped_inventory_unit = order.inventory_units[0]
-        @unshipped_inventory_unit = order.inventory_units[1]
-        order.shipping.ship(
-          inventory_units: [@shipped_inventory_unit],
-          stock_location: @shipment.stock_location,
-          address: order.ship_address,
-          shipping_method: @shipment.shipping_method,
-        )
-
-        # Create an expedited exchange for the shipped inventory unit.
-        # This generates a new inventory unit attached to the existing line item.
-        Spree::ReturnAuthorization.create!(
-          order: order,
-          stock_location: @shipment.stock_location,
-          reason: create(:return_authorization_reason),
-          return_items: [
-            Spree::ReturnItem.new(
-              inventory_unit: @shipped_inventory_unit,
-              exchange_variant: exchange_variant,
-            ),
-          ],
-        )
-        @exchange_inventory_unit = order.inventory_units.reload[2]
-      end
-
-      context 'when canceling an unshipped inventory unit from the original order' do
-        subject do
-          unit_cancel.compute_amount(@unshipped_inventory_unit.line_item)
-        end
-
-        let(:unit_cancel) do
-          Spree::UnitCancel.create!(
-            inventory_unit: @unshipped_inventory_unit,
-            reason: Spree::UnitCancel::SHORT_SHIP,
-          )
-        end
-
-        it { is_expected.to eq(-10.00) }
-      end
-
-      context 'when canceling an unshipped exchange inventory unit' do
-        subject do
-          unit_cancel.compute_amount(@exchange_inventory_unit.line_item)
-        end
-
-        let(:unit_cancel) do
-          Spree::UnitCancel.create!(
-            inventory_unit: @exchange_inventory_unit,
-            reason: Spree::UnitCancel::SHORT_SHIP,
-          )
-        end
-
-        it { is_expected.to eq(-10.00) }
       end
     end
   end

--- a/core/spec/models/spree/unprocessed_inventory_unit_amount_calculator_spec.rb
+++ b/core/spec/models/spree/unprocessed_inventory_unit_amount_calculator_spec.rb
@@ -28,7 +28,10 @@ describe Spree::UnprocessedInventoryUnitAmountCalculator do
       let!(:inventory_unit2) { create(:inventory_unit, line_item: inventory_unit.line_item, order: inventory_unit.order) }
       let(:carton1) { create(:carton, inventory_units: [inventory_unit2]) }
 
-      before { Spree::CartonCapturing.new(carton1).capture }
+      before do
+        allow_any_instance_of(Spree::CartonPaymentStrategy).to receive(:capture_payments)
+        Spree::CartonCapturing.new(carton1).capture
+      end
 
       it "calculates the promotion total based on captured inventory" do
         expect(subject).to eq 4.55
@@ -59,7 +62,10 @@ describe Spree::UnprocessedInventoryUnitAmountCalculator do
       let!(:inventory_unit2) { create(:inventory_unit, line_item: inventory_unit.line_item, order: inventory_unit.order) }
       let(:carton1) { create(:carton, inventory_units: [inventory_unit2]) }
 
-      before { Spree::CartonCapturing.new(carton1).capture }
+      before do
+        allow_any_instance_of(Spree::CartonPaymentStrategy).to receive(:capture_payments)
+        Spree::CartonCapturing.new(carton1).capture
+      end
 
       it "calculates the promotion total based on captured inventory" do
         expect(subject).to eq 4.55
@@ -91,7 +97,10 @@ describe Spree::UnprocessedInventoryUnitAmountCalculator do
       let!(:inventory_unit2) { create(:inventory_unit, line_item: inventory_unit.line_item, order: inventory_unit.order) }
       let(:carton1) { create(:carton, inventory_units: [inventory_unit2]) }
 
-      before { Spree::CartonCapturing.new(carton1).capture }
+      before do
+        allow_any_instance_of(Spree::CartonPaymentStrategy).to receive(:capture_payments)
+        Spree::CartonCapturing.new(carton1).capture
+      end
 
       it "calculates the tax total based on captured inventory" do
         expect(subject).to eq 4.55
@@ -122,7 +131,10 @@ describe Spree::UnprocessedInventoryUnitAmountCalculator do
       let!(:inventory_unit2) { create(:inventory_unit, line_item: inventory_unit.line_item, order: inventory_unit.order) }
       let(:carton1) { create(:carton, inventory_units: [inventory_unit2]) }
 
-      before { Spree::CartonCapturing.new(carton1).capture }
+      before do
+        allow_any_instance_of(Spree::CartonPaymentStrategy).to receive(:capture_payments)
+        Spree::CartonCapturing.new(carton1).capture
+      end
 
       it "calculates the tax total based on captured inventory" do
         expect(subject).to eq 4.55
@@ -134,7 +146,10 @@ describe Spree::UnprocessedInventoryUnitAmountCalculator do
     subject { calculator }
     let(:carton1) { create(:carton, inventory_units: [inventory_unit]) }
 
-    before { Spree::CartonCapturing.new(carton1).capture }
+    before do
+      allow_any_instance_of(Spree::CartonPaymentStrategy).to receive(:capture_payments)
+      Spree::CartonCapturing.new(carton1).capture
+    end
 
     it "raises an error when initializing" do
       expect { subject }.to raise_error(Spree::UnprocessedInventoryUnitAmountCalculator::InventoryPreviouslyProcessedError)

--- a/core/spec/models/spree/unprocessed_inventory_unit_amount_calculator_spec.rb
+++ b/core/spec/models/spree/unprocessed_inventory_unit_amount_calculator_spec.rb
@@ -1,0 +1,161 @@
+require 'spec_helper'
+
+describe Spree::UnprocessedInventoryUnitAmountCalculator do
+  let(:calculator) { Spree::UnprocessedInventoryUnitAmountCalculator.new(inventory_unit) }
+  let(:order) { create(:order_ready_to_ship) }
+  let!(:inventory_unit) { order.inventory_units.first }
+
+  context "when inventory has promotions" do
+    subject { calculator.promotion_total }
+
+    before { allow_any_instance_of(Spree::LineItem).to receive(:promo_total).and_return(9.11) }
+
+    it "calculates the promotion total" do
+      expect(subject).to eq 9.11
+    end
+
+    context "when there is a previously canceled inventory unit" do
+      let!(:inventory_unit2) { create(:inventory_unit, line_item: inventory_unit.line_item, order: inventory_unit.order) }
+
+      before { Spree::OrderCancellations.new(order).short_ship([inventory_unit2]) }
+
+      it "calculates the promotion total based on canceled inventory" do
+        expect(subject).to eq 4.55
+      end
+    end
+
+    context "when there is a previously captured inventory unit" do
+      let!(:inventory_unit2) { create(:inventory_unit, line_item: inventory_unit.line_item, order: inventory_unit.order) }
+      let(:carton1) { create(:carton, inventory_units: [inventory_unit2]) }
+
+      before { Spree::CartonCapturing.new(carton1).capture }
+
+      it "calculates the promotion total based on captured inventory" do
+        expect(subject).to eq 4.55
+      end
+    end
+  end
+
+  context "when order has order promotions" do
+    subject { calculator.order_adjustment_total }
+
+    before { Spree::Adjustment.create!(order: order, adjustable: order, label: 'Some Label', amount: 9.11) }
+
+    it "calculates the promotion total" do
+      expect(subject).to eq 9.11.to_d
+    end
+
+    context "when there is a previously canceled inventory unit" do
+      let!(:inventory_unit2) { create(:inventory_unit, line_item: inventory_unit.line_item, order: inventory_unit.order) }
+
+      before { Spree::OrderCancellations.new(order).short_ship([inventory_unit2]) }
+
+      it "calculates the promotion total based on canceled inventory" do
+        expect(subject).to eq 4.55
+      end
+    end
+
+    context "when there is a previously captured inventory unit" do
+      let!(:inventory_unit2) { create(:inventory_unit, line_item: inventory_unit.line_item, order: inventory_unit.order) }
+      let(:carton1) { create(:carton, inventory_units: [inventory_unit2]) }
+
+      before { Spree::CartonCapturing.new(carton1).capture }
+
+      it "calculates the promotion total based on captured inventory" do
+        expect(subject).to eq 4.55
+      end
+    end
+
+  end
+
+  context "when inventory has included tax" do
+    subject { calculator.included_tax_total }
+
+    before { allow_any_instance_of(Spree::LineItem).to receive(:included_tax_total).and_return(9.11) }
+
+    it "calculates the tax total" do
+      expect(subject).to eq 9.11
+    end
+
+    context "when there is a previously canceled inventory unit" do
+      let!(:inventory_unit2) { create(:inventory_unit, line_item: inventory_unit.line_item, order: inventory_unit.order) }
+
+      before { Spree::OrderCancellations.new(order).short_ship([inventory_unit2]) }
+
+      it "calculates the tax total based on canceled inventory" do
+        expect(subject).to eq 4.55
+      end
+    end
+
+    context "when there is a previously captured inventory unit" do
+      let!(:inventory_unit2) { create(:inventory_unit, line_item: inventory_unit.line_item, order: inventory_unit.order) }
+      let(:carton1) { create(:carton, inventory_units: [inventory_unit2]) }
+
+      before { Spree::CartonCapturing.new(carton1).capture }
+
+      it "calculates the tax total based on captured inventory" do
+        expect(subject).to eq 4.55
+      end
+    end
+  end
+
+  context "when inventory has additional tax" do
+    subject { calculator.additional_tax_total }
+
+    before { allow_any_instance_of(Spree::LineItem).to receive(:additional_tax_total).and_return(9.11) }
+
+    it "calculates the tax total" do
+      expect(subject).to eq 9.11
+    end
+
+    context "when there is a previously canceled inventory unit" do
+      let!(:inventory_unit2) { create(:inventory_unit, line_item: inventory_unit.line_item, order: inventory_unit.order) }
+
+      before { Spree::OrderCancellations.new(order).short_ship([inventory_unit2]) }
+
+      it "calculates the tax total based on canceled inventory" do
+        expect(subject).to eq 4.55
+      end
+    end
+
+    context "when there is a previously captured inventory unit" do
+      let!(:inventory_unit2) { create(:inventory_unit, line_item: inventory_unit.line_item, order: inventory_unit.order) }
+      let(:carton1) { create(:carton, inventory_units: [inventory_unit2]) }
+
+      before { Spree::CartonCapturing.new(carton1).capture }
+
+      it "calculates the tax total based on captured inventory" do
+        expect(subject).to eq 4.55
+      end
+    end
+  end
+
+  context "when we have already captured for the inventory" do
+    subject { calculator }
+    let(:carton1) { create(:carton, inventory_units: [inventory_unit]) }
+
+    before { Spree::CartonCapturing.new(carton1).capture }
+
+    it "raises an error when initializing" do
+      expect { subject }.to raise_error(Spree::UnprocessedInventoryUnitAmountCalculator::InventoryPreviouslyProcessedError)
+    end
+  end
+
+  context "when we have already canceled the inventory" do
+    subject { calculator }
+
+    before { Spree::OrderCancellations.new(order).short_ship([inventory_unit]) }
+
+    it "raises an error when initializing" do
+      expect { subject }.to raise_error(Spree::UnprocessedInventoryUnitAmountCalculator::InventoryPreviouslyProcessedError)
+    end
+  end
+
+  describe "#currency" do
+    subject { calculator.currency }
+
+    it "returns the line item's currency" do
+      expect(subject).to eq inventory_unit.line_item.currency
+    end
+  end
+end


### PR DESCRIPTION
Ability to capture at ship
    
This update adds the ability to automatically capture funds at ship time. You can now set the "auto_capture_at_ship" preference to true and orders will be captured at ship time instead of at order completion time.

Note: If you set auto_capture_at_ship to true you need to ensure that you set auto_capture (at completion) to false.

* CartonCapturing class to charge cards and create records of amounts charged per inventory unit
* CartonPaymentStrategy class to determine the ordering of payments to charge
* UnprocessedInventoryUnitAmountCalculator class to calculate breakdowns for captures and unit cancels
* UnitCancel now stores breakdowns for totals
* If you capture part of a payment it will split into a second one with the uncaptured amount
* Spree::Config[:auto_capture_at_ship] to turn it all on