### PR TITLE
Don't swallow the stacktrace

### DIFF
--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -30,148 +30,118 @@ module Spree
             order.update_totals
             order.persist_totals
             order.reload
-          rescue Exception => e
+          rescue Exception
             order.destroy if order && order.persisted?
-            raise e.message
+            raise
           end
         end
 
         def self.create_shipments_from_params(shipments_hash, order)
           return [] unless shipments_hash
           shipments_hash.each do |s|
-            begin
-              shipment = order.shipments.build
-              shipment.tracking = s[:tracking]
-              shipment.stock_location = Spree::StockLocation.find_by_name!(s[:stock_location])
+            shipment = order.shipments.build
+            shipment.tracking = s[:tracking]
+            shipment.stock_location = Spree::StockLocation.find_by_name!(s[:stock_location])
 
-              inventory_units = s[:inventory_units] || []
-              inventory_units.each do |iu|
-                ensure_variant_id_from_params(iu)
+            inventory_units = s[:inventory_units] || []
+            inventory_units.each do |iu|
+              ensure_variant_id_from_params(iu)
 
-                unit = shipment.inventory_units.build
-                unit.order = order
-                unit.variant_id = iu[:variant_id]
-              end
-
-              shipment.save!
-
-              shipping_method = Spree::ShippingMethod.find_by_name!(s[:shipping_method])
-              rate = shipment.shipping_rates.create!(:shipping_method => shipping_method,
-                                                     :cost => s[:cost])
-              shipment.selected_shipping_rate_id = rate.id
-
-            rescue Exception => e
-              raise "Order import shipments: #{e.message} #{s}"
+              unit = shipment.inventory_units.build
+              unit.order = order
+              unit.variant_id = iu[:variant_id]
             end
+
+            shipment.save!
+
+            shipping_method = Spree::ShippingMethod.find_by_name!(s[:shipping_method])
+            rate = shipment.shipping_rates.create!(:shipping_method => shipping_method,
+                                                   :cost => s[:cost])
+            shipment.selected_shipping_rate_id = rate.id
           end
         end
 
         def self.create_line_items_from_params(line_items_hash, order)
           return {} unless line_items_hash
           line_items_hash.each_key do |k|
-            begin
-              line_item = line_items_hash[k]
-              ensure_variant_id_from_params(line_item)
+            line_item = line_items_hash[k]
+            ensure_variant_id_from_params(line_item)
 
-              extra_params = line_item.except(:variant_id, :quantity)
-              line_item = order.contents.add(Spree::Variant.find(line_item[:variant_id]), line_item[:quantity])
-              line_item.update_attributes(extra_params) unless extra_params.empty?
-            rescue Exception => e
-              raise "Order import line items: #{e.message} #{line_item}"
-            end
+            extra_params = line_item.except(:variant_id, :quantity)
+            line_item = order.contents.add(Spree::Variant.find(line_item[:variant_id]), line_item[:quantity])
+            line_item.update_attributes(extra_params) unless extra_params.empty?
           end
         end
 
         def self.create_adjustments_from_params(adjustments, order)
           return [] unless adjustments
           adjustments.each do |a|
-            begin
-              adjustment = order.adjustments.build(
-                order:  order,
-                amount: a[:amount].to_d,
-                label:  a[:label]
-              )
-              adjustment.save!
-              adjustment.close!
-            rescue Exception => e
-              raise "Order import adjustments: #{e.message} #{a}"
-            end
+            adjustment = order.adjustments.build(
+              order:  order,
+              amount: a[:amount].to_d,
+              label:  a[:label]
+            )
+            adjustment.save!
+            adjustment.close!
           end
         end
 
         def self.create_payments_from_params(payments_hash, order)
           return [] unless payments_hash
           payments_hash.each do |p|
-            begin
-              payment, success = order.contents.add_payment(
-                payment_params: {
-                  amount: p[:amount].to_d,
-                  state: p.fetch(:state, 'completed'),
-                  payment_method: Spree::PaymentMethod.find_by_name!(p[:payment_method])
-                }
-              )
-              raise payment.errors unless success
-            rescue Exception => e
-              raise "Order import payments: #{e.message} #{p}"
-            end
+            payment, success = order.contents.add_payment(
+              payment_params: {
+                amount: p[:amount].to_d,
+                state: p.fetch(:state, 'completed'),
+                payment_method: Spree::PaymentMethod.find_by_name!(p[:payment_method])
+              }
+            )
+            raise payment.errors unless success
           end
         end
 
         def self.ensure_variant_id_from_params(hash)
-          begin
-            unless hash[:variant_id].present?
-              hash[:variant_id] = Spree::Variant.active.find_by_sku!(hash[:sku]).id
-              hash.delete(:sku)
-            end
-          rescue Exception => e
-            raise "Ensure order import variant: #{e.message} #{hash}"
+          unless hash[:variant_id].present?
+            hash[:variant_id] = Spree::Variant.active.find_by_sku!(hash[:sku]).id
+            hash.delete(:sku)
           end
         end
 
         def self.ensure_country_id_from_params(address)
           return if address.nil? or address[:country_id].present? or address[:country].nil?
 
-          begin
-            search = {}
-            if name = address[:country]['name']
-              search[:name] = name
-            elsif iso_name = address[:country]['iso_name']
-              search[:iso_name] = iso_name.upcase
-            elsif iso = address[:country]['iso']
-              search[:iso] = iso.upcase
-            elsif iso3 = address[:country]['iso3']
-              search[:iso3] = iso3.upcase
-            end
-
-            address.delete(:country)
-            address[:country_id] = Spree::Country.where(search).first!.id
-
-          rescue Exception => e
-            raise "Ensure order import address country: #{e.message} #{search}"
+          search = {}
+          if name = address[:country]['name']
+            search[:name] = name
+          elsif iso_name = address[:country]['iso_name']
+            search[:iso_name] = iso_name.upcase
+          elsif iso = address[:country]['iso']
+            search[:iso] = iso.upcase
+          elsif iso3 = address[:country]['iso3']
+            search[:iso3] = iso3.upcase
           end
+
+          address.delete(:country)
+          address[:country_id] = Spree::Country.where(search).first!.id
         end
 
         def self.ensure_state_id_from_params(address)
           return if address.nil? or address[:state_id].present? or address[:state].nil?
 
-          begin
-            search = {}
-            if name = address[:state]['name']
-              search[:name] = name
-            elsif abbr = address[:state]['abbr']
-              search[:abbr] = abbr.upcase
-            end
+          search = {}
+          if name = address[:state]['name']
+            search[:name] = name
+          elsif abbr = address[:state]['abbr']
+            search[:abbr] = abbr.upcase
+          end
 
-            address.delete(:state)
-            search[:country_id] = address[:country_id]
+          address.delete(:state)
+          search[:country_id] = address[:country_id]
 
-            if state = Spree::State.where(search).first
-              address[:state_id] = state.id
-            else
-              address[:state_name] = search[:name] || search[:abbr]
-            end
-          rescue Exception => e
-            raise "Ensure order import address state: #{e.message} #{search}"
+          if state = Spree::State.where(search).first
+            address[:state_id] = state.id
+          else
+            address[:state_name] = search[:name] || search[:abbr]
           end
         end
 

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -96,15 +96,6 @@ module Spree
         line_item.variant_id.should == variant_id
       end
 
-      it 'handles line_item building exceptions' do
-        line_items['0'][:variant_id] = 'XXX'
-        params = { :line_items_attributes => line_items }
-
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
-      end
-
       it 'can build an order from API with variant sku' do
         params = { :line_items_attributes => {
                      "0" => { :sku => sku, :quantity => 5 } }}
@@ -114,14 +105,6 @@ module Spree
         line_item = order.line_items.first
         line_item.variant_id.should == variant_id
         line_item.quantity.should == 5
-      end
-
-      it 'handles exceptions when sku is not found' do
-        params = { :line_items_attributes => {
-                     "0" => { :sku => 'XXX', :quantity => 5 } }}
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
       end
 
       it 'can build an order from API shipping address' do
@@ -140,17 +123,6 @@ module Spree
 
         order = Importer::Order.import(user,params)
         order.ship_address.country.iso.should eq 'US'
-      end
-
-      it 'handles country lookup exceptions' do
-        ship_address.delete(:country_id)
-        ship_address[:country] = { 'iso' => 'XXX' }
-        params = { :ship_address_attributes => ship_address,
-                   :line_items_attributes => line_items }
-
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
       end
 
       it 'can build an order from API with state attributes' do
@@ -269,17 +241,6 @@ module Spree
         end
       end
 
-      it 'handles shipment building exceptions' do
-        params = { :shipments_attributes => [{ tracking: '123456789',
-                                               cost: '4.99',
-                                               shipping_method: 'XXX',
-                                               inventory_units: [{ sku: sku }]
-                                             }] }
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
-      end
-
       it 'adds adjustments' do
         params = { :adjustments_attributes => [
             { label: 'Shipping Discount', amount: -4.99 },
@@ -310,29 +271,11 @@ module Spree
 
       end
 
-      it 'handles adjustment building exceptions' do
-        params = { :adjustments_attributes => [
-            { amount: 'XXX' },
-            { label: 'Promotion Discount', amount: '-3.00' }] }
-
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
-      end
-
       it 'builds a payment' do
         params = { :payments_attributes => [{ amount: '4.99',
                                               payment_method: payment_method.name }] }
         order = Importer::Order.import(user,params)
         order.payments.first.amount.should eq 4.99
-      end
-
-      it 'handles payment building exceptions' do
-        params = { :payments_attributes => [{ amount: '4.99',
-                                              payment_method: 'XXX' }] }
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
       end
 
       context "raises error" do

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -194,7 +194,7 @@ module Spree
         address = { :country => { "name" => "NoNoCountry" } }
         expect {
           Importer::Order.ensure_country_id_from_params(address)
-        }.to raise_error /NoNoCountry/
+        }.to raise_error ActiveRecord::RecordNotFound
       end
 
       it 'ensures_state_id for state fields' do


### PR DESCRIPTION
Instead of capturing and rethrowing exceptions for no reason, allow the
actual exception to bubble up so that it becomes possible to debug
issues.