### PR TITLE
OrderCapturing

### DIFF
--- a/core/app/models/spree/order_capturing.rb
+++ b/core/app/models/spree/order_capturing.rb
@@ -1,0 +1,32 @@
+class Spree::OrderCapturing
+  class_attribute :eligible_payments
+  self.eligible_payments = []
+
+  def initialize(order)
+    @order = order
+  end
+
+  def capture_payments
+    return if @order.paid?
+
+    Spree::OrderMutex.with_lock!(@order) do
+      uncaptured_amount = @order.total
+
+      while uncaptured_amount > 0 do
+        payment = sorted_eligible_payments(@order).shift
+        break unless payment
+
+        amount = [uncaptured_amount, payment.amount].min
+        payment.capture!((amount * 100).to_i)
+        uncaptured_amount -= amount
+      end
+    end
+  end
+
+  private
+
+  def sorted_eligible_payments(order)
+    payments = order.reload.pending_payments
+    payments = payments.sort_by { |p| [eligible_payments.index(p.payment_method.class), p.id] }
+  end
+end

--- a/core/spec/models/spree/order_capturing_spec.rb
+++ b/core/spec/models/spree/order_capturing_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Spree::OrderCapturing do
+  describe '#capture_payments' do
+    subject { Spree::OrderCapturing.new(order).capture_payments }
+
+    let(:order) { create(:completed_order_with_pending_payment) }
+
+    context 'the order has already been paid for' do
+      before { Spree::OrderCapturing.new(order).capture_payments }
+
+      it 'does not process payments' do
+        expect_any_instance_of(Spree::Payment).not_to receive(:capture!)
+        subject
+      end
+    end
+
+    it 'processes payments for the order' do
+      expect(order.paid?).to eq false
+      subject
+      expect(order.reload.paid?).to eq true
+    end
+  end
+end


### PR DESCRIPTION
Added a service object that allows you to capture payments for an `Spree::Order` in a certain order.

We don't have plans to hook this up to much of anything in spree itself -- we are going to have a cron job that will use it -- but thought it would be good to submit it here first in case there is interest in something like this more broadly. One example: It might be something we could put in place of OrderContents#process_payments in the future. Opinions definitely welcome.

cc @cbrunsdon @jordan-brough 