### PR TITLE
Fix issue with insufficient stock validation when completing an order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -565,9 +565,7 @@ module Spree
 
       def validate_line_item_availability
         availability_validator = Spree::Stock::AvailabilityValidator.new
-
-        errors = line_items.map { |line_item| availability_validator.validate(line_item) }.compact
-        raise Spree::LineItem::InsufficientStock if errors.any?
+        raise Spree::LineItem::InsufficientStock unless line_items.all? { |line_item| availability_validator.validate(line_item) }
       end
 
       def has_available_shipment

--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -2,9 +2,24 @@ module Spree
   module Stock
     class AvailabilityValidator < ActiveModel::Validator
       def validate(line_item)
-        quantifier = Stock::Quantifier.new(line_item.variant)
+        units_by_shipment = line_item.inventory_units.group_by(&:shipment)
 
-        unless quantifier.can_supply? line_item.quantity
+        if units_by_shipment.blank?
+          ensure_in_stock(line_item, line_item.quantity)
+        else
+          units_by_shipment.each do |shipment, inventory_units|
+            ensure_in_stock(line_item, inventory_units.size, shipment.stock_location)
+          end
+        end
+
+        line_item.errors[:quantity].empty?
+      end
+
+      private
+
+      def ensure_in_stock(line_item, quantity, stock_location = nil)
+        quantifier = Stock::Quantifier.new(line_item.variant, stock_location)
+        unless quantifier.can_supply?(quantity)
           variant = line_item.variant
           display_name = %Q{#{variant.name}}
           display_name += %Q{ (#{variant.options_text})} unless variant.options_text.blank?

--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -3,9 +3,15 @@ module Spree
     class Quantifier
       attr_reader :stock_items
 
-      def initialize(variant)
+      def initialize(variant, stock_location = nil)
         @variant = variant
-        @stock_items = Spree::StockItem.joins(:stock_location).where(:variant_id => @variant, Spree::StockLocation.table_name =>{ :active => true})
+        where_args = { variant_id: @variant }
+        if stock_location
+          where_args.merge!(stock_location: stock_location)
+        else
+          where_args.merge!(Spree::StockLocation.table_name => { active: true })
+        end
+        @stock_items = Spree::StockItem.joins(:stock_location).where(where_args)
       end
 
       def total_on_hand

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -409,6 +409,7 @@ describe Spree::Order do
         # make sure we will actually capture a payment
         order.stub(payment_required?: true)
         order.stub(ensure_available_shipping_rates: true)
+        order.stub(validate_line_item_availability: true)
         order.line_items << FactoryGirl.create(:line_item)
         order.line_items.each { |li| li.inventory_units.create! }
         Spree::OrderUpdater.new(order).update
@@ -441,6 +442,7 @@ describe Spree::Order do
         # make sure we will actually capture a payment
         order.stub(payment_required?: true)
         order.stub(ensure_available_shipping_rates: true)
+        order.stub(validate_line_item_availability: true)
         order.line_items << FactoryGirl.create(:line_item)
         order.line_items.each { |li| li.inventory_units.create! }
         Spree::OrderUpdater.new(order).update
@@ -521,7 +523,7 @@ describe Spree::Order do
     it "does not attempt to process payments" do
       order.stub(:ensure_available_shipping_rates).and_return(true)
       order.stub_chain(:line_items, :present?).and_return(true)
-      order.stub_chain(:line_items, :map).and_return([])
+      order.stub(validate_line_item_availability: true)
       order.should_not_receive(:payment_required?)
       order.should_not_receive(:process_payments!)
       order.next!

--- a/core/spec/models/spree/stock/availability_validator_spec.rb
+++ b/core/spec/models/spree/stock/availability_validator_spec.rb
@@ -3,20 +3,79 @@ require 'spec_helper'
 module Spree
   module Stock
     describe AvailabilityValidator do
-      let!(:line_item) { double(quantity: 5, variant_id: 1, variant: double.as_null_object, errors: double('errors'), inventory_units: []) }
+      let(:validator) { Spree::Stock::AvailabilityValidator.new }
 
-      subject { described_class.new(nil) }
+      subject { validator.validate(line_item) }
 
-      it 'should be valid when supply is sufficient' do
-        Stock::Quantifier.any_instance.stub(can_supply?: true)
-        line_item.should_not_receive(:errors)
-        subject.validate(line_item)
+      shared_examples_for "fails validation" do
+        it "returns false" do
+          expect(subject).to eq false
+        end
+
+        it "adds a validation error" do
+          subject
+          display_name = "#{line_item.variant.name} (#{line_item.variant.options_text})"
+          expect(line_item.errors).to match_array ["Quantity selected of #{display_name.inspect} is not available."]
+        end
       end
 
-      it 'should be invalid when supply is insufficent' do
-        Stock::Quantifier.any_instance.stub(can_supply?: false)
-        line_item.errors.should_receive(:[]).with(:quantity).and_return []
-        subject.validate(line_item)
+      shared_examples_for "passes validation" do
+        it "returns true" do
+          expect(subject).to eq true
+        end
+
+        it "doesn't add a validation error" do
+          expect(line_item.errors).to be_empty
+        end
+      end
+
+      context "line_item is not part of a shipment" do
+        let(:line_item) { create(:line_item) }
+
+        context "has stock in all stock locations" do
+          before do
+            Spree::StockItem.where(variant_id: line_item.variant_id).update_all(count_on_hand: 10, backorderable: false)
+          end
+
+          include_examples "passes validation"
+        end
+
+        context "doesn't have stock in any stock location" do
+          before do
+            Spree::StockItem.where(variant_id: line_item.variant_id).update_all(count_on_hand: 0, backorderable: false)
+          end
+
+          include_examples "fails validation"
+        end
+      end
+
+      context "line_item is part of a shipment" do
+        let!(:order)            { create(:order_with_line_items) }
+
+        context "has stock in all stock locations" do
+          let(:line_item)         { order.line_items.first }
+
+          before do
+            variant_ids = order.line_items.map(&:variant_id)
+            Spree::StockItem.where(variant_id: variant_ids).update_all(count_on_hand: 10, backorderable: false)
+          end
+
+          include_examples "passes validation"
+        end
+
+        context "doesn't have stock in a particular stock location" do
+          let(:variant)           { create(:variant) }
+          let(:line_item)         { order.line_items.find_by(variant_id: variant.id) }
+          let!(:stock_location_1) { create(:stock_location, name: "Test Warehouse", active: false) }
+
+          before do
+            order.contents.add(variant, stock_location_quantities: { stock_location_1.id => 1})
+            order.contents.advance
+            stock_location_1.stock_items.update_all(count_on_hand: 0, backorderable: false)
+          end
+
+          include_examples "fails validation"
+        end
       end
     end
   end

--- a/core/spec/models/spree/stock/quantifier_spec.rb
+++ b/core/spec/models/spree/stock/quantifier_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 shared_examples_for 'unlimited supply' do
   it 'can_supply? any amount' do
-    subject.can_supply?(1).should be true
-    subject.can_supply?(101).should be true
-    subject.can_supply?(100_001).should be true
+    expect(subject.can_supply?(1)).to eq true
+    expect(subject.can_supply?(101)).to eq true
+    expect(subject.can_supply?(100_001)).to eq true
   end
 end
 
@@ -14,23 +14,24 @@ module Spree
 
       before(:all) { Spree::StockLocation.destroy_all } #FIXME leaky database
 
+      let(:target_stock_location) { nil }
       let!(:stock_location) { create :stock_location_with_items  }
       let!(:stock_item) { stock_location.stock_items.order(:id).first }
 
-      subject { described_class.new(stock_item.variant) }
+      subject { described_class.new(stock_item.variant, target_stock_location) }
 
-      specify { subject.stock_items.should == [stock_item] }
+      specify { expect(subject.stock_items).to eq [stock_item] }
 
 
       context 'with a single stock location/item' do
         it 'total_on_hand should match stock_item' do
-          subject.total_on_hand.should ==  stock_item.count_on_hand
+          expect(subject.total_on_hand).to eq stock_item.count_on_hand
         end
 
         context 'when track_inventory_levels is false' do
           before { configure_spree_preferences { |config| config.track_inventory_levels = false } }
 
-          specify { subject.total_on_hand.should == Float::INFINITY }
+          specify { expect(subject.total_on_hand).to eq Float::INFINITY }
 
           it_should_behave_like 'unlimited supply'
         end
@@ -38,14 +39,14 @@ module Spree
         context 'when variant inventory tracking is off' do
           before { stock_item.variant.track_inventory = false }
 
-          specify { subject.total_on_hand.should == Float::INFINITY }
+          specify { expect(subject.total_on_hand).to eq Float::INFINITY }
 
           it_should_behave_like 'unlimited supply'
         end
 
         context 'when stock item allows backordering' do
 
-          specify { subject.backorderable?.should be true }
+          specify { expect(subject.backorderable?).to eq true }
 
           it_should_behave_like 'unlimited supply'
         end
@@ -53,12 +54,12 @@ module Spree
         context 'when stock item prevents backordering' do
           before { stock_item.update_attributes(backorderable: false) }
 
-          specify { subject.backorderable?.should be false }
+          specify { expect(subject.backorderable?).to eq false }
 
           it 'can_supply? only upto total_on_hand' do
-            subject.can_supply?(1).should be true
-            subject.can_supply?(10).should be true
-            subject.can_supply?(11).should be false
+            expect(subject.can_supply?(1)).to eq true
+            expect(subject.can_supply?(10)).to eq true
+            expect(subject.can_supply?(11)).to eq false
           end
         end
 
@@ -74,11 +75,11 @@ module Spree
         end
 
         it 'total_on_hand should total all active stock_items' do
-          subject.total_on_hand.should == 15
+          expect(subject.total_on_hand).to eq 15
         end
 
         context 'when any stock item allows backordering' do
-          specify { subject.backorderable?.should be true }
+          specify { expect(subject.backorderable?).to eq true }
 
           it_should_behave_like 'unlimited supply'
         end
@@ -86,15 +87,31 @@ module Spree
         context 'when all stock items prevent backordering' do
           before { stock_item.update_attributes(backorderable: false) }
 
-          specify { subject.backorderable?.should be false }
+          specify { expect(subject.backorderable?).to eq false }
 
           it 'can_supply? upto total_on_hand' do
-            subject.can_supply?(1).should be true
-            subject.can_supply?(15).should be true
-            subject.can_supply?(16).should be false
+            expect(subject.can_supply?(1)).to eq true
+            expect(subject.can_supply?(15)).to eq true
+            expect(subject.can_supply?(16)).to eq false
           end
         end
 
+      end
+
+      context 'with a specific stock location' do
+        let!(:stock_location_2)     { create :stock_location }
+        let!(:stock_location_3)     { create :stock_location, active: false }
+        let(:target_stock_location) { stock_location_3 }
+
+        before do
+          Spree::StockItem.update_all(count_on_hand: 0, backorderable: false)
+          stock_location_3.stock_items.where(variant_id: stock_item.variant).update_all(count_on_hand: 5, backorderable: false)
+        end
+
+        it 'can_supply? only upto total_on_hand' do
+          expect(subject.can_supply?(5)).to eq true
+          expect(subject.can_supply?(6)).to eq false
+        end
       end
 
     end

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -145,7 +145,7 @@ describe Spree::CheckoutController do
           # An order requires a payment to reach the complete state
           # This is because payment_required? is true on the order
           create(:payment, :amount => order.total, :order => order)
-          order.line_items.each {|li| li.inventory_units.create! }
+          create(:shipment, order: order)
           order.payments.reload
         end
 


### PR DESCRIPTION
The current validation that checks whether there is stock for a variant when completing an order will check to see if there is stock in *any active* stock location. When adding a variant from a specific stock location, this validation is incorrect because it doesn’t check the stock in the stock location it’s meant to be shipped out of. This will also not validate correctly if the stock location is inactive because as long as there is an active stock location with stock for the variant, the validation would pass.