### PR TITLE
Order capturing changes

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -57,6 +57,7 @@ module Spree
     preference :layout, :string, default: 'spree/layouts/spree_application'
     preference :logo, :string, default: 'logo/spree_50.png'
     preference :max_level_in_taxons_menu, :integer, default: 1 # maximum nesting level in taxons menu
+    preference :order_capturing_time_window, :integer, default: 14 # the number of days to look back for fully-shipped/cancelled orders in order to charge for them
     preference :order_mutex_max_age, :integer, default: 2.minutes
     preference :orders_per_page, :integer, default: 15
     preference :prices_inc_tax, :boolean, default: false

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -36,6 +36,7 @@ module Spree
     preference :alternative_shipping_phone, :boolean, default: false # Request extra phone for ship addr
     preference :always_put_site_name_in_title, :boolean, default: true
     preference :auto_capture, :boolean, default: false # automatically capture the credit card (as opposed to just authorize and capture later)
+    preference :auto_capture_exchanges, :boolean, default: false # automatically capture the credit card (as opposed to just authorize and capture later)
     preference :binary_inventory_cache, :boolean, default: false # only invalidate product cache when a stock item changes whether it is in_stock
     preference :checkout_zone, :string, default: nil # replace with the name of a zone if you would like to limit the countries
     preference :company, :boolean, default: false # Request company field for billing and shipping addr

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -65,6 +65,7 @@ module Spree
     preference :customer_returns_per_page, :integer, default: 15
     preference :redirect_https_to_http, :boolean, :default => false
     preference :require_master_price, :boolean, default: true
+    preference :require_payment_to_ship, :boolean, default: true # Allows shipments to be ready to ship regardless of the order being paid if false
     preference :return_eligibility_number_of_days, :integer, default: 365
     preference :shipment_inc_vat, :boolean, default: false
     preference :shipping_instructions, :boolean, default: false # Request instructions/info for shipping

--- a/core/app/models/spree/order_capturing.rb
+++ b/core/app/models/spree/order_capturing.rb
@@ -1,0 +1,35 @@
+class Spree::OrderCapturing
+  # Allows for prioritizing payment methods in the order to be captured
+  class_attribute :sorted_payment_method_classes
+  self.sorted_payment_method_classes = []
+
+  def initialize(order, sorted_payment_method_classes = nil)
+    @order = order
+    @sorted_payment_method_classes = sorted_payment_method_classes || Spree::OrderCapturing.sorted_payment_method_classes
+  end
+
+  def capture_payments
+    return if @order.paid?
+
+    Spree::OrderMutex.with_lock!(@order) do
+      uncaptured_amount = @order.display_total.cents
+
+      begin
+        sorted_payments(@order).each do |payment|
+          amount = [uncaptured_amount, payment.money.cents].min
+          payment.capture!(amount)
+          uncaptured_amount -= amount
+        end
+      ensure
+        @order.update!
+      end
+    end
+  end
+
+  private
+
+  def sorted_payments(order)
+    payments = order.pending_payments
+    payments = payments.sort_by { |p| [@sorted_payment_method_classes.index(p.payment_method.class), p.id] }
+  end
+end

--- a/core/app/models/spree/order_capturing.rb
+++ b/core/app/models/spree/order_capturing.rb
@@ -17,6 +17,8 @@ class Spree::OrderCapturing
       begin
         sorted_payments(@order).each do |payment|
           amount = [uncaptured_amount, payment.money.cents].min
+          break unless amount > 0
+
           payment.capture!(amount)
           uncaptured_amount -= amount
         end

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -63,7 +63,7 @@ class Spree::OrderShipping
       # TODO: Remove tracking numbers from shipments.
       shipment.update_attributes!(tracking: tracking_number)
 
-      if shipment.inventory_units.all?(&:shipped?)
+      if shipment.inventory_units.all? {|iu| iu.shipped? || iu.canceled? }
         # TODO: make OrderShipping#ship_shipment call Shipment#ship! rather than
         # having Shipment#ship! call OrderShipping#ship_shipment. We only really
         # need this `update_columns` for the specs, until we make that change.

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -152,7 +152,11 @@ module Spree
     end
 
     def uncaptured_amount
-      amount - capture_events.sum(:amount)
+      amount - captured_amount
+    end
+
+    def captured_amount
+      capture_events.sum(:amount)
     end
 
     private

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -188,7 +188,7 @@ module Spree
       end
 
       def invalidate_old_payments
-        order.payments.with_state('checkout').where("id != ?", self.id).each do |payment|
+        order.payments.with_state('checkout').where(payment_method_id: payment_method.try(:id)).where("id != ?", self.id).each do |payment|
           payment.invalidate!
         end
       end

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -52,6 +52,7 @@ module Spree
 
           money = ::Money.new(amount, Spree::Config[:currency])
           capture_events.create!(amount: money.to_f)
+          update_attributes!(amount: captured_amount)
           handle_response(response, :complete, :failure)
         end
       end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -75,7 +75,8 @@ module Spree
     end
 
     def can_transition_from_pending_to_ready?
-      order.can_ship? && !inventory_units.any?(&:backordered?) && order.paid?
+      order.can_ship? && !inventory_units.any?(&:backordered?) &&
+        (order.paid? || !Spree::Config[:require_payment_to_ship])
     end
 
     def can_transition_from_canceled_to_ready?
@@ -221,7 +222,11 @@ module Spree
       return 'pending' unless order.can_ship?
       return 'pending' if inventory_units.any? &:backordered?
       return 'shipped' if state == 'shipped'
-      order.paid? ? 'ready' : 'pending'
+      if order.paid? || !Spree::Config[:require_payment_to_ship]
+        'ready'
+      else
+        'pending'
+      end
     end
 
     def tracking_url

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -34,6 +34,7 @@ module Spree
 
       new_order.contents.approve(name: self.class.name)
       new_order.reload.complete!
+      new_order.payments.map(&:capture!) if (Spree::Config[:auto_capture_exchanges] && !Spree::Config[:auto_capture])
 
       @return_items.each(&:expired!)
       create_new_rma if Spree::Config[:create_rma_for_unreturned_exchange]

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -34,7 +34,7 @@ module Spree
 
       new_order.contents.approve(name: self.class.name)
       new_order.reload.complete!
-      new_order.payments.map(&:capture!) if (Spree::Config[:auto_capture_exchanges] && !Spree::Config[:auto_capture])
+      Spree::OrderCapturing.new(new_order).capture_payments if (Spree::Config[:auto_capture_exchanges] && !Spree::Config[:auto_capture])
 
       @return_items.each(&:expired!)
       create_new_rma if Spree::Config[:create_rma_for_unreturned_exchange]

--- a/core/lib/tasks/order_capturing.rake
+++ b/core/lib/tasks/order_capturing.rake
@@ -1,0 +1,11 @@
+namespace :order_capturing do
+  desc "Looks for orders with inventory that is fully shipped/short-shipped, and captures money for it"
+  task capture_payments: :environment do
+    orders = Spree::Order.complete.where(payment_state: 'balance_due').where('completed_at > ?', Spree::Config[:order_capturing_time_window].days.ago)
+    orders.find_each do |order|
+      if order.inventory_units.all? {|iu| iu.canceled? || iu.shipped? }
+        Spree::OrderCapturing.new(order).capture_payments
+      end
+    end
+  end
+end

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -92,15 +92,46 @@ describe "exchanges:charge_unreturned_items" do
         expect(new_order.credit_cards.first).to eq order.valid_credit_cards.first
       end
 
-      it "authorizes the order for the full amount of the unreturned items including taxes" do
-        expect { subject.invoke }.to change { Spree::Payment.count }.by(1)
-        new_order = Spree::Order.last
-        expected_amount = return_item_2.reload.exchange_variant.price + new_order.additional_tax_total + new_order.included_tax_total + new_order.shipment_total
-        expect(new_order.total).to eq expected_amount
-        payment = new_order.payments.first
-        expect(payment.amount).to eq expected_amount
-        expect(payment).to be_pending
-        expect(new_order.item_total).to eq return_item_2.reload.exchange_variant.price
+      context "payments" do
+        it "authorizes the order for the full amount of the unreturned items including taxes" do
+          expect { subject.invoke }.to change { Spree::Payment.count }.by(1)
+          new_order = Spree::Order.last
+          expected_amount = return_item_2.reload.exchange_variant.price + new_order.additional_tax_total + new_order.included_tax_total + new_order.shipment_total
+          expect(new_order.total).to eq expected_amount
+          payment = new_order.payments.first
+          expect(payment.amount).to eq expected_amount
+          expect(new_order.item_total).to eq return_item_2.reload.exchange_variant.price
+        end
+
+        context "auto_capture_exchanges is true" do
+          before do
+            @original_auto_capture_exchanges = Spree::Config[:auto_capture_exchanges]
+            Spree::Config[:auto_capture_exchanges] = true
+          end
+
+          after { Spree::Config[:auto_capture_exchanges] = @original_auto_capture_exchanges }
+
+          it 'creates a pending payment' do
+            expect { subject.invoke }.to change { Spree::Payment.count }.by(1)
+            payment = Spree::Payment.last
+            expect(payment).to be_completed
+          end
+        end
+
+        context "auto_capture_exchanges is false" do
+          before do
+            @original_auto_capture_exchanges = Spree::Config[:auto_capture_exchanges]
+            Spree::Config[:auto_capture_exchanges] = false
+          end
+
+          after { Spree::Config[:auto_capture_exchanges] = @original_auto_capture_exchanges }
+
+          it 'captures payment' do
+            expect { subject.invoke }.to change { Spree::Payment.count }.by(1)
+            payment = Spree::Payment.last
+            expect(payment).to be_pending
+          end
+        end
       end
 
       it "does not attempt to create a new order for the item more than once" do

--- a/core/spec/lib/tasks/order_capturing_spec.rb
+++ b/core/spec/lib/tasks/order_capturing_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe "order_capturing:capture_payments" do
+  include_context "rake"
+
+  its(:prerequisites) { should include("environment") }
+  let(:order) { create(:completed_order_with_pending_payment, line_items_count: 2) }
+  let(:payment) { order.payments.first }
+
+  context "with a mix of canceled and shipped inventory" do
+    before do
+      Spree::OrderCancellations.new(order).short_ship([order.inventory_units.first])
+      order.shipping.ship_shipment(order.shipments.first)
+      order.update_attributes!(payment_state: 'balance_due')
+    end
+
+    it "charges the order" do
+      expect(order.inventory_units.any?(&:on_hand?)).to eq false
+      expect(order.inventory_units.all? {|iu| iu.canceled? || iu.shipped? }).to eq true
+      expect {
+        expect { subject.invoke }.to change { payment.reload.state }.to('completed')
+      }.to change { order.reload.payment_state }.to('paid')
+    end
+  end
+
+  context "with any inventory not shipped or canceled" do
+    it "does not charge for the order" do
+      expect(order.inventory_units.any?(&:on_hand?)).to eq true
+      expect {
+        expect { subject.invoke }.not_to change { payment.reload }
+      }.not_to change { order.reload.payment_state }
+    end
+  end
+end

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -6,6 +6,7 @@ describe Spree::OrderCancellations do
 
     let(:order) { create(:order_ready_to_ship, line_items_count: 1) }
     let(:inventory_unit) { order.inventory_units.first }
+    let(:shipment) { inventory_unit.shipment }
 
     it "creates a UnitCancel record" do
       expect { subject }.to change { Spree::UnitCancel.count }.by(1)
@@ -17,6 +18,14 @@ describe Spree::OrderCancellations do
 
     it "cancels the inventory unit" do
       expect { subject }.to change { inventory_unit.state }.to "canceled"
+    end
+
+    it "updates the shipment.state" do
+      expect { subject }.to change { shipment.reload.state }.from('ready').to('shipped')
+    end
+
+    it "updates the order.shipment_state" do
+      expect { subject }.to change { order.shipment_state }.from('ready').to('shipped')
     end
 
     it "adjusts the order" do

--- a/core/spec/models/spree/order_capturing_spec.rb
+++ b/core/spec/models/spree/order_capturing_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+describe Spree::OrderCapturing do
+  describe '#capture_payments' do
+    subject { Spree::OrderCapturing.new(order, payment_methods).capture_payments }
+
+    context "payment methods specified" do
+      let!(:order) { create(:order, ship_address: create(:address)) }
+
+      let!(:product) { create(:product, price: 10.00) }
+      let!(:variant) do
+        create(:variant, price: 10, product: product, track_inventory: false, tax_category: tax_rate.tax_category)
+      end
+      let!(:shipping_method) { create(:free_shipping_method) }
+      let(:tax_rate) { create(:tax_rate, amount: 0.1, zone: create(:global_zone, name: "Some Tax Zone")) }
+      let(:secondary_total) { 10.0 }
+      let(:bogus_total) { order.total }
+
+      before do
+        order.contents.add(variant, 3)
+        order.update!
+        @secondary_bogus_payment = create(:payment, order: order, amount: secondary_total, payment_method: secondary_payment_method.create!(name: 'So bogus', environment: 'test'))
+        @bogus_payment = create(:payment, order: order, amount: bogus_total)
+        order.contents.advance
+        order.complete!
+        order.reload
+      end
+
+      context "payment method ordering" do
+        let(:secondary_payment_method) { SecondaryBogusPaymentMethod }
+
+        class SecondaryBogusPaymentMethod < Spree::Gateway::Bogus; end
+
+        context "SecondaryBogusPaymentMethod payments are prioritized" do
+          let(:payment_methods) { [SecondaryBogusPaymentMethod, Spree::Gateway::Bogus] }
+
+          it "captures SecondaryBogusPaymentMethod payments first" do
+            subject
+            expect(@secondary_bogus_payment.reload.capture_events.sum(:amount)).to eq(10.0)
+            expect(@bogus_payment.reload.capture_events.sum(:amount)).to eq(order.total - 10.0)
+          end
+        end
+
+        context "Bogus payments are prioritized" do
+          let(:payment_methods) { [Spree::Gateway::Bogus, SecondaryBogusPaymentMethod] }
+
+          it "captures Bogus payments first" do
+            subject
+            expect(@secondary_bogus_payment.reload.capture_events.sum(:amount)).to eq(0.0)
+            expect(@bogus_payment.reload.capture_events.sum(:amount)).to eq(order.total)
+          end
+        end
+
+        context "when the payment method ordering is configured" do
+          subject { Spree::OrderCapturing.new(order, payment_methods).capture_payments }
+
+          let(:payment_methods) { nil }
+
+          before do
+            allow(Spree::OrderCapturing).to receive(:sorted_payment_method_classes).and_return(
+              [SecondaryBogusPaymentMethod, Spree::Gateway::Bogus]
+            )
+          end
+
+          it "captures in the order specified" do
+            subject
+            expect(@secondary_bogus_payment.reload.capture_events.sum(:amount)).to eq(10.0)
+            expect(@bogus_payment.reload.capture_events.sum(:amount)).to eq(order.total - 10.0)
+          end
+        end
+      end
+
+      context "when there is an error processing a payment" do
+        let(:secondary_payment_method) { ExceptionallyBogusPaymentMethod }
+        let(:bogus_total) { order.total - 1 }
+        let(:secondary_total) { 1 }
+        let(:payment_methods) { [Spree::Gateway::Bogus, ExceptionallyBogusPaymentMethod] }
+
+        class ExceptionallyBogusPaymentMethod < Spree::Gateway::Bogus
+          def capture(*args)
+            raise ActiveMerchant::ConnectionError
+          end
+        end
+
+        it "raises an error and leaves the order in a reasonable state" do
+          expect { subject }.to raise_error(Spree::Core::GatewayError)
+          expect(order.payments.to_a.sum(&:uncaptured_amount)).to eq 1.0
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/order_shipping_spec.rb
+++ b/core/spec/models/spree/order_shipping_spec.rb
@@ -121,6 +121,16 @@ describe Spree::OrderShipping do
       end
     end
 
+    context "when all units are canceled or shipped" do
+      let(:order) { create(:order_ready_to_ship, line_items_count: 2) }
+
+      before { Spree::OrderCancellations.new(order).short_ship([order.inventory_units.first]) }
+
+      it "updates the order shipment state" do
+        expect { subject }.to change { order.reload.shipment_state }.from('ready').to('shipped')
+      end
+    end
+
     context "with an external_number" do
       subject do
         order.shipping.ship_shipment(

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -309,9 +309,14 @@ describe Spree::Payment do
             expect(payment.capture_events.first.amount).to eq(50)
           end
 
-          it "stores the uncaptured amount on the payment" do
+          it "stores the captured amount on the payment" do
             payment.capture!(6000)
-            expect(payment.uncaptured_amount).to eq(40) # 100 - 60 = 40
+            expect(payment.captured_amount).to eq(60)
+          end
+
+          it "updates the amount of the payment" do
+            payment.capture!(6000)
+            expect(payment.reload.amount).to eq(60)
           end
         end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -217,6 +217,24 @@ describe Spree::Shipment do
       it_should_behave_like 'pending if backordered'
     end
 
+    context "when payment is not required" do
+      before do
+        @original_require_payment = Spree::Config[:require_payment_to_ship]
+        Spree::Config[:require_payment_to_ship] = false
+      end
+
+      after do
+        Spree::Config[:require_payment_to_ship] = @original_require_payment
+      end
+
+      it "should result in a 'ready' state" do
+        shipment.should_receive(:update_columns).with(state: 'ready', updated_at: kind_of(Time))
+        shipment.update!(order)
+      end
+      it_should_behave_like 'immutable once shipped'
+      it_should_behave_like 'pending if backordered'
+    end
+
     context "when order has balance due" do
       before { order.stub paid?: false }
       it "should result in a 'pending' state" do


### PR DESCRIPTION
* Config for auto_capture_exchanges
** I felt like this should be independent of auto_capturing orders. For instance, we will have auto_capture false in Bonobos, but want to auto capture for exchanges.

* Partial capture updates payment amount
** This is a change we are getting from spree 2-4 anyway, but needed it for current work until we upgrade to Solidus

* Clean up shipment state machine
** We needed to hook into the conditions of how a shipment can go to the ready state, but this was impossible. Also this gets us a little less dependent on `Shipment#determine_state` which seems like one of the most insane methods I've seen.

cc @jordan-brough @athal7 @cbrunsdon @gmacdougall @jhawthorn 