### PR TITLE
Move Stock Transfers to Stock header

### DIFF
--- a/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -21,7 +21,6 @@
       <%= configurations_sidebar_menu_item Spree.t(:taxonomies), admin_taxonomies_path %>
       <%= configurations_sidebar_menu_item Spree.t(:shipping_methods), admin_shipping_methods_path %>
       <%= configurations_sidebar_menu_item Spree.t(:shipping_categories), admin_shipping_categories_path %>
-      <%= configurations_sidebar_menu_item Spree.t(:stock_transfers), admin_stock_transfers_path %>
       <%= configurations_sidebar_menu_item Spree.t(:stock_locations), spree.admin_stock_locations_path %>
       <%= configurations_sidebar_menu_item Spree.t(:analytics_trackers), admin_trackers_path %>
       <%= configurations_sidebar_menu_item Spree.t(:refund_reasons), admin_refund_reasons_path %>

--- a/backend/app/views/spree/admin/shared/_stock_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_stock_sub_menu.html.erb
@@ -1,0 +1,6 @@
+<% content_for :sub_menu do %>
+  <ul id="sub_nav" data-hook="admin_stock_transfer_sub_tabs" class="inline-menu">
+    <%= tab :stock_items, :label => 'management', :match_path => '/stock_items' %>
+    <%= tab :stock_transfers, :label => 'transfers', :match_path => '/stock_transfers' %>
+  </ul>
+<% end %>

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -7,12 +7,12 @@
 <% if can? :admin, Spree::Admin::ReportsController %>
   <%= tab :reports, :icon => 'file'  %>
 <% end %>
-<%= tab :configurations, :general_settings, :mail_methods, :tax_categories, :tax_rates, :tax_settings, :zones, :countries, :states, :payment_methods, :shipping_methods, :shipping_categories, :stock_transfers, :stock_locations, :trackers, :label => 'settings', :icon => 'wrench', :url => spree.edit_admin_general_settings_path %>
+<%= tab :configurations, :general_settings, :mail_methods, :tax_categories, :tax_rates, :tax_settings, :zones, :countries, :states, :payment_methods, :shipping_methods, :shipping_categories, :stock_locations, :trackers, :label => 'settings', :icon => 'wrench', :url => spree.edit_admin_general_settings_path %>
 <% if can? :admin, Spree::Promotion %>
   <%= tab(:promotions, :url => spree.admin_promotions_path, :icon => 'bullhorn') %>
 <% end %>
 <% if can? :admin, Spree::StockLocation %>
-  <%= tab(:stock_items, :url => spree.admin_stock_items_path, :label => 'stock', :icon => 'cubes', match_path: %r(^/admin/stock)) %>
+  <%= tab(:stock_items, :stock_transfers, :url => spree.admin_stock_items_path, :label => 'stock', :icon => 'cubes', match_path: %r(^/admin/stock)) %>
 <% end %>
 <% if Spree.user_class && can?(:admin, Spree.user_class) %>
   <%= tab(:users, :url => spree.admin_users_path, :icon => 'user') %>

--- a/backend/app/views/spree/admin/stock_items/index.html.erb
+++ b/backend/app/views/spree/admin/stock_items/index.html.erb
@@ -7,6 +7,7 @@
   <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Stock Management' } %>
   <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @product } %>
 <% else %>
+  <%= render :partial => 'spree/admin/shared/stock_sub_menu' %>
   <% content_for :page_title do %>
     <%= Spree.t(:manage_stock) %>
   <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/edit.html.erb
@@ -1,8 +1,8 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
 <%= render :partial => 'transfer_item_template' %>
 <%= render :partial => "spree/admin/variants/autocomplete", formats: :js %>
 
-<% content_for :page_title do %>
+<%= render :partial => 'spree/admin/shared/stock_sub_menu' %>
+<%content_for :page_title do %>
   <%= "#{Spree.t(:editing_stock_transfer)} #{@stock_transfer.number}" %>
 <% end %>
 

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -1,3 +1,5 @@
+<%= render :partial => 'spree/admin/shared/stock_sub_menu' %>
+
 <% content_for :page_title do %>
   <%= Spree.t(:stock_transfers) %>
 <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/new.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render :partial => 'spree/admin/shared/stock_sub_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_stock_transfer) %>

--- a/backend/app/views/spree/admin/stock_transfers/receive.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/receive.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render :partial => 'spree/admin/shared/stock_sub_menu' %>
 <%= render :partial => 'transfer_item_template' %>
 <%= render :partial => "spree/admin/variants/autocomplete", :formats => :js %>
 

--- a/backend/app/views/spree/admin/stock_transfers/show.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/show.html.erb
@@ -1,3 +1,5 @@
+<%= render :partial => 'spree/admin/shared/stock_sub_menu' %>
+
 <% content_for :page_title do %>
   <%= Spree.t('stock_transfer') %> <%= @stock_transfer.number %>
 <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
@@ -1,3 +1,5 @@
+<%= render :partial => 'spree/admin/shared/stock_sub_menu' %>
+
 <% content_for :page_title do %>
   <%= "#{Spree.t(:ship)} #{Spree.t(:stock_transfer)} \##{@stock_transfer.number}" %>
 <% end %>


### PR DESCRIPTION
Take Stock Transfer management out of Settings, and put it in the Stock
header with stock management.