### PR TITLE
Add ability to override stock check when saving a transfer item

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -42,6 +42,10 @@
             <%= f.label :active, Spree.t(:fulfillable_stock) %>
             <%= f.check_box :fulfillable %>
           </li>
+          <li>
+            <%= f.label :check_stock_on_transfer, Spree.t(:check_stock_on_transfer) %>
+            <%= f.check_box :check_stock_on_transfer %>
+          </li>
         </ul>
       <% end %>
     </div>

--- a/core/app/models/spree/transfer_item.rb
+++ b/core/app/models/spree/transfer_item.rb
@@ -3,7 +3,7 @@ module Spree
     belongs_to :stock_transfer
     belongs_to :variant
 
-    validate :stock_availability, unless: :stock_transfer_closed?
+    validate :stock_availability, if: :check_stock?
     validates_presence_of :stock_transfer, :variant
     validates_uniqueness_of :variant_id, scope: :stock_transfer_id
     validates :expected_quantity, numericality: { greater_than: 0 }
@@ -39,6 +39,10 @@ module Spree
 
     def stock_transfer_closed?
       stock_transfer.closed?
+    end
+
+    def check_stock?
+      !stock_transfer_closed? && stock_transfer.source_location.check_stock_on_transfer?
     end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -527,6 +527,7 @@ en:
     categories: Categories
     category: Category
     charged: Charged
+    check_stock_on_transfer: Check stock on transfer
     checkout: Checkout
     choose_a_customer: Choose a customer
     choose_a_taxon_to_sort_products_for: "Choose a taxon to sort products for"

--- a/core/db/migrate/20150515170322_add_check_stock_on_transfer.rb
+++ b/core/db/migrate/20150515170322_add_check_stock_on_transfer.rb
@@ -1,0 +1,5 @@
+class AddCheckStockOnTransfer < ActiveRecord::Migration
+  def change
+    add_column :spree_stock_locations, :check_stock_on_transfer, :boolean, default: true
+  end
+end

--- a/core/spec/models/spree/transfer_item_spec.rb
+++ b/core/spec/models/spree/transfer_item_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Spree::TransferItem do
-  let(:stock_transfer) { create(:stock_transfer_with_items) }
+  let(:stock_location) { create(:stock_location, name: "Warehouse") }
+  let(:stock_transfer) { create(:stock_transfer_with_items, source_location: stock_location) }
   let(:transfer_item)  { stock_transfer.transfer_items.first }
 
   subject { transfer_item }
@@ -78,6 +79,13 @@ describe Spree::TransferItem do
             stock_item.set_count_on_hand(0)
           end
           include_examples 'availability check passes'
+
+          context "stock location doesn't check stock" do
+            before do
+              stock_location.update_attributes!(check_stock_on_transfer: false)
+            end
+            include_examples 'availability check passes'
+          end
         end
 
         context "variant available" do
@@ -105,6 +113,13 @@ describe Spree::TransferItem do
             stock_item.set_count_on_hand(0)
           end
           include_examples 'availability check fails'
+
+          context "stock location doesn't check stock" do
+            before do
+              stock_location.update_attributes!(check_stock_on_transfer: false)
+            end
+            include_examples 'availability check passes'
+          end
         end
 
         context "variant available" do


### PR DESCRIPTION
Adds the ability to bypass the validation that checks the presence of stock when saving a transfer item. The setting can be enabled/disabled per stock location. Includes the UI to enable/disable the setting.