### PR TITLE
More granular permissions around shipping a shipment.

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -54,6 +54,7 @@ module Spree
       end
 
       def ship
+        authorize! :ship, @shipment
         unless @shipment.shipped?
           @shipment.ship!
         end

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -10,7 +10,7 @@
         <span class="shipment-state"><%= Spree.t("shipment_states.#{shipment.state}") %></span>
         <%= Spree.t(:package_from) %>
         <strong class="stock-location-name" data-hook="stock-location-name">'<%= shipment.stock_location.name %>'</strong>
-        <% if shipment.ready? && can?(:update, shipment) %>
+        <% if shipment.ready? && can?(:ship, shipment) %>
           <%= (' - ' + link_to(Spree.t(:ship), '#', :class => 'ship button fa fa-arrow-right', :data => {'shipment-number' => shipment.number})).html_safe %>
         <% end %>
       </legend>


### PR DESCRIPTION
The act of shipping a shipment is far different from amending a shipment
to have different items in it, so it seems worth it to have a separate
permission around it that we can assign to people separately.