### PR TITLE
Fix expected quantity auto-incrementing on stock transfer edit

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/stock_transfers/variant_form.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfers/variant_form.coffee
@@ -42,7 +42,7 @@ class VariantForm
       transferItem = new Spree.TransferItem
         id: transferItemId
         stockTransferNumber: stockTransferNumber
-        expectedQuantity: expectedQuantity
+        expectedQuantity: expectedQuantity + 1
       transferItem.update(updateSuccessHandler, errorHandler)
     else
       transferItem = new Spree.TransferItem


### PR DESCRIPTION
When a variant that already exists in the stock transfer is added again, it should increment the current expected value by 1. I wasn’t incrementing the parsed value so the expected quantity would never change.