### PR TITLE
Fix OrderMutex to only rescue its own errors

### DIFF
--- a/core/spec/models/spree/order_mutex_spec.rb
+++ b/core/spec/models/spree/order_mutex_spec.rb
@@ -66,4 +66,31 @@ describe Spree::OrderMutex do
       expect(calls).to eq 1
     end
   end
+
+  context "when an unrelated RecordNotUnique error occurs" do
+    with_model 'Widget' do
+      table do |t|
+        t.integer :order_id
+      end
+    end
+
+    before do
+      ActiveRecord::Base.connection.add_index Widget.table_name, :order_id, unique: true
+    end
+
+    def raise_record_not_unique
+      Widget.create!(order_id: 1)
+      Widget.create!(order_id: 1)
+    end
+
+    it "does not rescue the unrelated error" do
+      Widget.create!(order_id: 1)
+
+      expect {
+        Spree::OrderMutex.with_lock!(order) do
+          raise_record_not_unique
+        end
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
 end

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -58,6 +58,7 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.include Spree::TestingSupport::Preferences
   config.include Spree::TestingSupport::Mail
+  config.extend WithModel
 
   config.fail_fast = ENV['FAIL_FAST'] || false
 end


### PR DESCRIPTION
In the previous code an ActiveRecord::RecordNotUnique that occurred
within the `yield` would get incorrectly rescued and transformed into
a `LockFailed` error.