### PR TITLE
Pull OrderUpdater#update_payment_state from Solidus

### DIFF
--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -66,8 +66,7 @@ describe 'Payments' do
       # end
     end
 
-    it 'should be able to list and create payment methods for an order', js: true do
-      find('#payment_status').text.should == 'PENDING'
+    it 'lists and create payments for an order', js: true do
       within_row(1) do
         column_text(3).should == '$110.00'
         column_text(4).should == 'Credit Card'
@@ -75,9 +74,7 @@ describe 'Payments' do
       end
 
       click_icon :void
-
-      # as it had a payment greater than order total ($50)
-      find('#payment_status').text.should == 'CREDIT OWED'
+      find('#payment_status').text.should == 'BALANCE DUE'
       page.should have_content('Payment Updated')
 
       within_row(1) do

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -281,11 +281,15 @@ module Spree
     end
 
     def outstanding_balance
-      total - payment_total
+      if state == 'canceled'
+        -1 * payment_total
+      else
+        total - payment_total
+      end
     end
 
     def outstanding_balance?
-     self.outstanding_balance != 0
+      self.outstanding_balance != 0
     end
 
     def name

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -147,38 +147,18 @@ module Spree
     #
     # The +payment_state+ value helps with reporting, etc. since it provides a quick and easy way to locate Orders needing attention.
     def update_payment_state
-      # line_item are empty when user empties cart
-      if line_items.empty? || round_money(order.payment_total) < round_money(order.total)
-        if payments.present?
-          # The gateway refunds the payment if possible when an order is canceled, so all canceled orders
-          # should have voided payments
-          if order.state == 'canceled'
-            order.payment_state = 'void'
-          elsif payments.last.state == 'failed'
-            order.payment_state = 'failed'
-          elsif payments.last.state == 'checkout'
-            order.payment_state = 'pending'
-          elsif payments.last.state == 'completed'
-            if line_items.empty?
-              order.payment_state = 'credit_owed'
-            else
-              order.payment_state = 'balance_due'
-            end
-          elsif payments.last.state == 'pending'
-            order.payment_state = 'balance_due'
-          else
-            order.payment_state = 'credit_owed'
-          end
-        else
-          order.payment_state = 'balance_due'
-        end
-      elsif round_money(order.payment_total) > round_money(order.total)
-        order.payment_state = 'credit_owed'
+      last_state = order.payment_state
+      if payments.present? && payments.valid.size == 0
+        order.payment_state = 'failed'
+      elsif order.state == 'canceled' && order.payment_total == 0
+        order.payment_state = 'void'
       else
-        order.payment_state = 'paid'
+        order.payment_state = 'balance_due' if order.outstanding_balance > 0
+        order.payment_state = 'credit_owed' if order.outstanding_balance < 0
+        order.payment_state = 'paid' if !order.outstanding_balance?
       end
-
-      order.state_changed('payment')
+      order.state_changed('payment') if last_state != order.payment_state
+      order.payment_state
     end
 
     private

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -108,70 +108,88 @@ module Spree
     end
 
     context "updating payment state" do
-      it "is void if the order is canceled with payments" do
-        order.stub(:state).and_return('canceled')
-        order.stub_chain(:payments, :present?).and_return('true')
+      let(:order) { Order.new }
+      let(:updater) { order.updater }
+
+      it "is failed if no valid payments" do
+        allow(order).to receive_message_chain(:payments, :valid, :size).and_return(0)
 
         updater.update_payment_state
-        order.payment_state.should == 'void'
+        expect(order.payment_state).to eq('failed')
       end
 
-      it "is failed if last payment failed" do
-        order.stub_chain(:payments, :last, :state).and_return('failed')
+      context "payment total is greater than order total" do
+        it "is credit_owed" do
+          order.payment_total = 2
+          order.total = 1
 
-        updater.update_payment_state
-        order.payment_state.should == 'failed'
+          expect {
+            updater.update_payment_state
+          }.to change { order.payment_state }.to 'credit_owed'
+        end
       end
 
-      # Regression test for #4281
-      it "is credit_owed if payment taken, but no line items" do
-        order.stub_chain(:line_items, :empty?).and_return(true)
-        order.stub_chain(:payments, :last, :state).and_return('completed')
+      context "order total is greater than payment total" do
+        it "is balance_due" do
+          order.payment_total = 1
+          order.total = 2
 
-        updater.update_payment_state
-        order.payment_state.should == 'credit_owed'
+          expect {
+            updater.update_payment_state
+          }.to change { order.payment_state }.to 'balance_due'
+        end
       end
 
-      it "is balance due with one pending payment" do
-        order.stub_chain(:payments, :last, :state).and_return('pending')
+      context "order total equals payment total" do
+        it "is paid" do
+          order.payment_total = 30
+          order.total = 30
 
-        updater.update_payment_state
-        order.payment_state.should == 'balance_due'
+          expect {
+            updater.update_payment_state
+          }.to change { order.payment_state }.to 'paid'
+        end
       end
 
-      it "is balance due with no line items" do
-        order.stub_chain(:line_items, :empty?).and_return(true)
+      context "order is canceled" do
 
-        updater.update_payment_state
-        order.payment_state.should == 'balance_due'
-      end
+        before do
+          order.state = 'canceled'
+        end
 
-      it "is credit owed if payment is above total" do
-        order.stub_chain(:line_items, :empty?).and_return(false)
-        order.stub :payment_total => 31
-        order.stub :total => 30
+        context "and is still unpaid" do
+          it "is void" do
+            order.payment_total = 0
+            order.total = 30
+            expect {
+              updater.update_payment_state
+            }.to change { order.payment_state }.to 'void'
+          end
+        end
 
-        updater.update_payment_state
-        order.payment_state.should == 'credit_owed'
-      end
+        context "and is paid" do
 
-      it "is paid if order is paid in full" do
-        order.stub_chain(:line_items, :empty?).and_return(false)
-        order.stub :payment_total => 30
-        order.stub :total => 30
+          it "is credit_owed" do
+            order.payment_total = 30
+            order.total = 30
+            allow(order).to receive_message_chain(:payments, :valid, :size).and_return(1)
+            allow(order).to receive_message_chain(:payments, :completed, :size).and_return(1)
+            expect {
+              updater.update_payment_state
+            }.to change { order.payment_state }.to 'credit_owed'
+          end
 
-        updater.update_payment_state
-        order.payment_state.should == 'paid'
-      end
+        end
 
-      it "is balance due if payment total is less than order total" do
-        order.stub_chain(:line_items, :empty?).and_return(false)
-        order.stub_chain(:payments, :last, :state).and_return('completed')
-        order.stub :payment_total => 29
-        order.stub :total => 30
-
-        updater.update_payment_state
-        order.payment_state.should == 'balance_due'
+        context "and payment is refunded" do
+          it "is void" do
+            order.payment_total = 0
+            order.total = 30
+            expect {
+              updater.update_payment_state
+            }.to change { order.payment_state }.to 'void'
+          end
+        end
       end
     end
 


### PR DESCRIPTION
The current update_payment_state is just broken and is messing things up for capture at ship. This is the current state of that method in Solidus, and will fix that issue.

cc @jordan-brough 