### PR TITLE
Allow the ability to suppress a shipment confirmation mailer.

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -56,6 +56,7 @@ module Spree
       def ship
         authorize! :ship, @shipment
         unless @shipment.shipped?
+          @shipment.suppress_mailer = (params[:send_mailer] == 'false')
           @shipment.ship!
         end
         respond_with(@shipment, default_template: :show)

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -30,6 +30,7 @@ Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
 
 require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'
+require 'spree/testing_support/mail'
 
 require 'spree/api/testing_support/caching'
 require 'spree/api/testing_support/helpers'
@@ -44,6 +45,7 @@ RSpec.configure do |config|
   config.include Spree::Api::TestingSupport::Helpers, :type => :controller
   config.extend Spree::Api::TestingSupport::Setup, :type => :controller
   config.include Spree::TestingSupport::Preferences
+  config.include Spree::TestingSupport::Mail
 
   config.fail_fast = ENV['FAIL_FAST'] || false
 

--- a/backend/app/assets/javascripts/spree/backend/shipments.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js.erb
@@ -58,19 +58,13 @@ $(document).ready(function () {
     }
   });
 
-  // handle ship click
-  $('[data-hook=admin_shipment_form] a.ship').on('click', function () {
-    var link = $(this);
-    var shipment_number = link.data('shipment-number');
-    var url = Spree.routes.shipments_api + '/' + shipment_number + '/ship.json';
-    Spree.ajax({
-      type: 'PUT',
-      url: url
-    }).done(function () {
-      window.location.reload();
-    }).error(function (msg) {
-      console.log(msg);
-    });
+  // add header to ship ujs ajax call
+  $("form#admin-ship-shipment").on("ajax:beforeSend", function(event, xhr, settings) {
+    xhr.setRequestHeader("X-Spree-Token", Spree.api_key);
+  });
+
+  $("form#admin-ship-shipment").on("ajax:success", function(event, xhr, settings) {
+    window.location.reload();
   });
 
   // handle shipping method edit click

--- a/backend/app/assets/stylesheets/spree/backend/sections/_orders.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_orders.scss
@@ -73,3 +73,9 @@
   color: #FFF;
   font-size: 2em;
 }
+
+form#admin-ship-shipment {
+  display: block;
+  text-align: center;
+  input[type='submit'] { margin-left: 5px; }
+}

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -10,10 +10,16 @@
         <span class="shipment-state"><%= Spree.t("shipment_states.#{shipment.state}") %></span>
         <%= Spree.t(:package_from) %>
         <strong class="stock-location-name" data-hook="stock-location-name">'<%= shipment.stock_location.name %>'</strong>
-        <% if shipment.ready? && can?(:ship, shipment) %>
-          <%= (' - ' + link_to(Spree.t(:ship), '#', :class => 'ship button fa fa-arrow-right', :data => {'shipment-number' => shipment.number})).html_safe %>
-        <% end %>
       </legend>
+
+      <% if shipment.ready? && can?(:ship, shipment) %>
+        <%= form_tag(spree.ship_api_shipment_path(shipment), { method: "PUT", remote: true, id: "admin-ship-shipment" }) do %>
+          <%= hidden_field_tag :send_mailer, false %>
+          <%= check_box_tag :send_mailer, true, true %>
+          <%= label_tag :send_mailer, Spree.t(:send_mailer) %>
+          <%= submit_tag Spree.t(:ship), class: "ship-shipment-button" %>
+        <% end %>
+      <% end %>
     </fieldset>
 
     <table class="stock-contents shipment index" data-hook="stock-contents">

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -528,7 +528,7 @@ describe "Order Details", js: true do
       order.contents.refresh_shipment_rates
       visit spree.edit_admin_order_path(order)
 
-      click_icon 'arrow-right'
+      find(".ship-shipment-button").click
       wait_for_ajax
 
       within '.carton-state' do

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -29,7 +29,7 @@ describe "Shipments" do
     end
 
     it "can ship a completed order" do
-      click_link "ship"
+      find(".ship-shipment-button").click
       wait_for_ajax
 
       page.should have_content("SHIPPED PACKAGE")

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -13,7 +13,7 @@ class Spree::OrderShipping
   # @param external_number An optional external number. e.g. from a shipping company or 3PL.
   # @param tracking_number An optional tracking number.
   # @return The carton created.
-  def ship_shipment(shipment, external_number: nil, tracking_number: nil)
+  def ship_shipment(shipment, external_number: nil, tracking_number: nil, suppress_mailer: false)
     ship(
       inventory_units: shipment.inventory_units.shippable,
       stock_location: shipment.stock_location,
@@ -24,6 +24,7 @@ class Spree::OrderShipping
       # TODO: Remove the `|| shipment.tracking` once Shipment#ship! is called by
       # OrderShipping#ship rather than vice versa
       tracking_number: tracking_number || shipment.tracking,
+      suppress_mailer: suppress_mailer,
     )
   end
 
@@ -40,7 +41,7 @@ class Spree::OrderShipping
   # @param tracking_number An option tracking number.
   # @return The carton created.
   def ship(inventory_units:, stock_location:, address:, shipping_method:,
-           shipped_at: Time.now, external_number: nil, tracking_number: nil)
+           shipped_at: Time.now, external_number: nil, tracking_number: nil, suppress_mailer: false)
 
     carton = nil
 
@@ -71,7 +72,7 @@ class Spree::OrderShipping
       end
     end
 
-    send_shipment_email(carton) if stock_location.fulfillable? # e.g. digital gift cards that aren't actually shipped
+    send_shipment_email(carton) if stock_location.fulfillable? && !suppress_mailer # e.g. digital gift cards that aren't actually shipped
     fulfill_order_stock_locations(stock_location)
     update_order_state
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -17,7 +17,9 @@ module Spree
 
     before_validation :set_cost_zero_when_nil
 
-    attr_accessor :special_instructions
+    # TODO remove the suppress_mailer temporary variable once we are calling 'ship'
+    # from outside of the state machine and can actually pass variables through.
+    attr_accessor :special_instructions, :suppress_mailer
 
     accepts_nested_attributes_for :address
     accepts_nested_attributes_for :inventory_units
@@ -380,7 +382,7 @@ module Spree
       def after_ship
         # TODO: Get this out of the model and have OrderShipping#ship_shipment
         # called directly everywhere
-        order.shipping.ship_shipment(self)
+        order.shipping.ship_shipment(self, suppress_mailer: suppress_mailer)
       end
 
       def set_cost_zero_when_nil

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1222,6 +1222,7 @@ en:
     select_stock: Select stock
     selected_quantity_not_available: ! 'selected of %{item} is not available.'
     send_copy_of_all_mails_to: Send Copy of All Mails To
+    send_mailer: Send Mailer
     send_mails_as: Send Mails As
     server: Server
     server_error: The server returned an error

--- a/core/spec/models/spree/order_shipping_spec.rb
+++ b/core/spec/models/spree/order_shipping_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe Spree::OrderShipping do
   let(:order) { create(:order_ready_to_ship, line_items_count: 1) }
 
+  def emails
+    ActionMailer::Base.deliveries
+  end
+
   shared_examples 'shipment shipping' do
 
     it "marks the inventory units as shipped" do
@@ -16,10 +20,6 @@ describe Spree::OrderShipping do
 
     describe "shipment email" do
       before { with_test_mail { subject } }
-
-      def emails
-        ActionMailer::Base.deliveries
-      end
 
       it "should send a shipment email" do
         expect(emails.size).to eq(1)
@@ -95,6 +95,24 @@ describe Spree::OrderShipping do
 
       it "sets the tracking-number" do
         expect(subject.tracking).to eq 'tracking-number'
+      end
+    end
+
+    context "when told to suppress the mailer" do
+      before { with_test_mail { subject } }
+
+      subject do
+        order.shipping.ship(
+          inventory_units: inventory_units,
+          stock_location: stock_location,
+          address: address,
+          shipping_method: shipping_method,
+          suppress_mailer: true,
+        )
+      end
+
+      it "does not send a shipment email" do
+        expect(emails.size).to eq(0)
       end
     end
 
@@ -193,5 +211,19 @@ describe Spree::OrderShipping do
       end
     end
 
+    context "when told to suppress the mailer" do
+      before { with_test_mail { subject } }
+
+      subject do
+        order.shipping.ship_shipment(
+          shipment,
+          suppress_mailer: true,
+        )
+      end
+
+      it "does not send a shipment email" do
+        expect(emails.size).to eq(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
Sometimes shipments need to be manually marked as shipped for a store
that usually automatically marks shipments as shipped. This can be due
to dropped communications with their fulfillment provider.

In these cases, marking a shipment as shipped manually is mainly for
data cleanup, and sending a shipment confirmation can create confusion.