### PR TITLE
Fixes incorrect variant images being displayed for certain variants

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -170,26 +170,22 @@ module Spree
       end
     end
 
-    def create_product_image_tag(image, product, options, style)
-      options.reverse_merge! alt: image.alt.blank? ? product.name : image.alt
+    def create_resource_image_tag(image, resource, options, style)
+      options.reverse_merge! alt: image.alt.presence || resource.try(:name)
       image_tag image.attachment.url(style), options
     end
 
     def define_image_method(style)
-      self.class.send :define_method, "#{style}_image" do |product, *options|
+      self.class.send :define_method, "#{style}_image" do |resource, *options|
         options = options.first || {}
-        if product.images.empty?
-          if !product.is_a?(Spree::Variant) && !product.variant_images.empty?
-            create_product_image_tag(product.variant_images.first, product, options, style)
+        if resource.images.empty?
+          if resource.is_a?(Spree::Product) && resource.variant_images.any?
+            create_resource_image_tag(resource.variant_images.first, resource, options, style)
           else
-            if product.is_a?(Variant) && !product.product.variant_images.empty?
-              create_product_image_tag(product.product.variant_images.first, product, options, style)
-            else
-              image_tag "noimage/#{style}.png", options
-            end
+            image_tag "noimage/#{style}.png", options
           end
         else
-          create_product_image_tag(product.images.first, product, options, style)
+          create_resource_image_tag(resource.images.first, resource, options, style)
         end
       end
     end


### PR DESCRIPTION
Currently when a variant is supplied to one of the generated image helpers and the variant does not have any associated images, the first of the variant’s product’s variant_images is used. The result is that incorrect images are displayed for certain variants. This can be misleading to admins since the image isn’t incorrect, it’s just not present. This change will display a “noimage” image when a variant is supplied to the image helper methods and it has no associated images.