### PR TITLE
OrderCapturing void unused payments

### DIFF
--- a/core/app/models/spree/order_capturing.rb
+++ b/core/app/models/spree/order_capturing.rb
@@ -3,6 +3,10 @@ class Spree::OrderCapturing
   class_attribute :sorted_payment_method_classes
   self.sorted_payment_method_classes = []
 
+  # Allows your store to void unused payments and release auths
+  class_attribute :void_unused_payments
+  self.void_unused_payments = true
+
   def initialize(order, sorted_payment_method_classes = nil)
     @order = order
     @sorted_payment_method_classes = sorted_payment_method_classes || Spree::OrderCapturing.sorted_payment_method_classes
@@ -17,10 +21,13 @@ class Spree::OrderCapturing
       begin
         sorted_payments(@order).each do |payment|
           amount = [uncaptured_amount, payment.money.cents].min
-          break unless amount > 0
 
-          payment.capture!(amount)
-          uncaptured_amount -= amount
+          if amount > 0
+            payment.capture!(amount)
+            uncaptured_amount -= amount
+          elsif Spree::OrderCapturing.void_unused_payments
+            payment.void_transaction!
+          end
         end
       ensure
         @order.update!

--- a/core/app/models/spree/order_capturing.rb
+++ b/core/app/models/spree/order_capturing.rb
@@ -5,7 +5,7 @@ class Spree::OrderCapturing
 
   # Allows your store to void unused payments and release auths
   class_attribute :void_unused_payments
-  self.void_unused_payments = true
+  self.void_unused_payments = false
 
   def initialize(order, sorted_payment_method_classes = nil)
     @order = order

--- a/core/spec/models/spree/order_capturing_spec.rb
+++ b/core/spec/models/spree/order_capturing_spec.rb
@@ -70,6 +70,18 @@ describe Spree::OrderCapturing do
         end
       end
 
+      context "when a payment is not needed to capture the entire order" do
+        let(:bogus_total) { order.total }
+        let(:secondary_payment_method) { SecondaryBogusPaymentMethod }
+        let(:payment_methods) { [Spree::Gateway::Bogus, SecondaryBogusPaymentMethod] }
+
+        it "captures for the order and voids the unused payment" do
+          subject
+          expect(order.reload.payment_state).to eq 'paid'
+          expect(@secondary_bogus_payment.reload.state).to eq 'void'
+        end
+      end
+
       context "when there is an error processing a payment" do
         let(:secondary_payment_method) { ExceptionallyBogusPaymentMethod }
         let(:bogus_total) { order.total - 1 }

--- a/core/spec/models/spree/order_capturing_spec.rb
+++ b/core/spec/models/spree/order_capturing_spec.rb
@@ -75,10 +75,22 @@ describe Spree::OrderCapturing do
         let(:secondary_payment_method) { SecondaryBogusPaymentMethod }
         let(:payment_methods) { [Spree::Gateway::Bogus, SecondaryBogusPaymentMethod] }
 
-        it "captures for the order and voids the unused payment" do
-          subject
-          expect(order.reload.payment_state).to eq 'paid'
-          expect(@secondary_bogus_payment.reload.state).to eq 'void'
+        context "when void_unused_payments is true" do
+          before { allow(Spree::OrderCapturing).to receive(:void_unused_payments).and_return(true) }
+
+          it "captures for the order and voids the unused payment" do
+            subject
+            expect(order.reload.payment_state).to eq 'paid'
+            expect(@secondary_bogus_payment.reload.state).to eq 'void'
+          end
+        end
+
+        context "when void_unused_payments is false" do
+          it "captures for the order and leaves the unused payment in a pending state" do
+            subject
+            expect(order.reload.payment_state).to eq 'paid'
+            expect(@secondary_bogus_payment.reload.state).to eq 'pending'
+          end
         end
       end
 


### PR DESCRIPTION
Allows your store to void completely unused payments when the order has been fully captured. It is set to true by default.