### PR TITLE
Authorize payment actions in admin controller

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -2,7 +2,8 @@ module Spree
   module Admin
     class PaymentsController < Spree::Admin::BaseController
       before_filter :load_order, :only => [:create, :new, :index, :fire]
-      before_filter :load_payment, :except => [:create, :new, :index]
+      before_filter :load_payment, :except => [:create, :new, :index, :fire]
+      before_filter :load_payment_for_fire, :only => :fire
       before_filter :load_data
       before_filter :can_not_transition_without_customer_info
 
@@ -87,6 +88,11 @@ module Spree
 
       def load_payment
         @payment = Payment.find(params[:id])
+      end
+
+      def load_payment_for_fire
+        load_payment
+        authorize! params[:e].to_sym, @payment
       end
 
       def model_class

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -21,7 +21,9 @@
         <td class="align-center"> <span class="state <%= payment.state %>"><%= Spree.t(payment.state, :scope => :payment_states, :default => payment.state.capitalize) %></span></td>
         <td class="actions">
           <% payment.actions.each do |action| %>
-            <% if action == 'credit' %>
+            <% if !can?(action.to_sym, payment) %>
+              <%# don't display things the user can't do %>
+            <% elsif action == 'credit' %>
               <%= link_to_with_icon 'reply', Spree.t(:refund), new_admin_order_payment_refund_path(@order, payment), no_text: true %>
             <% elsif action == 'capture' && !@order.completed? %>
               <%# no capture prior to completion. payments get captured when the order completes. %>

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -20,10 +20,9 @@
         <td class="align-center"><%= payment.transaction_id %></td>
         <td class="align-center"> <span class="state <%= payment.state %>"><%= Spree.t(payment.state, :scope => :payment_states, :default => payment.state.capitalize) %></span></td>
         <td class="actions">
-          <% payment.actions.each do |action| %>
-            <% if !can?(action.to_sym, payment) %>
-              <%# don't display things the user can't do %>
-            <% elsif action == 'credit' %>
+          <% allowed_actions = payment.actions.select { |a| can?(a.to_sym, payment) } %>
+          <% allowed_actions.each do |action| %>
+            <% if action == 'credit' %>
               <%= link_to_with_icon 'reply', Spree.t(:refund), new_admin_order_payment_refund_path(@order, payment), no_text: true %>
             <% elsif action == 'capture' && !@order.completed? %>
               <%# no capture prior to completion. payments get captured when the order completes. %>

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -3,8 +3,11 @@ require 'spec_helper'
 module Spree
   module Admin
     describe PaymentsController do
-      stub_authorization!
+      before do
+        controller.stub :spree_current_user => user
+      end
 
+      let(:user) { create(:admin_user) }
       let(:order) { create(:order) }
 
       context "with a valid credit card" do
@@ -85,6 +88,54 @@ module Spree
         it "should redirect to the customer details page" do
           spree_get :index, { amount: 100, order_id: order.number }
           expect(response).to redirect_to(spree.edit_admin_order_customer_path(order))
+        end
+      end
+
+      describe 'fire' do
+        describe 'authorization' do
+          let(:payment) { create(:payment, state: 'checkout') }
+          let(:order) { payment.order }
+
+          context 'the user is authorized' do
+            class CaptureAllowedAbility
+              include CanCan::Ability
+
+              def initialize(user)
+                can :capture, Spree::Payment
+              end
+            end
+
+            before do
+              Spree::Ability.register_ability(CaptureAllowedAbility)
+            end
+
+            it 'allows the action' do
+              expect {
+                spree_post(:fire, id: payment.to_param, e: 'capture', order_id: order.to_param)
+              }.to change { payment.reload.state }.from('checkout').to('completed')
+            end
+          end
+
+          context 'the user is not authorized' do
+            class CaptureNotAllowedAbility
+              include CanCan::Ability
+
+              def initialize(user)
+                cannot :capture, Spree::Payment
+              end
+            end
+
+            before do
+              Spree::Ability.register_ability(CaptureNotAllowedAbility)
+            end
+
+            it 'does not allow the action' do
+              expect {
+                spree_post(:fire, id: payment.to_param, e: 'capture', order_id: order.to_param)
+              }.to_not change { payment.reload.state }
+              expect(flash[:error]).to eq('Authorization Failure')
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Like we do in the API payments controller:
https://github.com/bonobos/spree/blob/a70c83c/api/app/controllers/spree/api/payments_controller.rb#L71

Also: Don't display unauthorized actions on the admin payment page.

@philbirt @athal7 @magnusvk @jhawthorn @gmacdougall @cbrunsdon 