### PR TITLE
Allow variant autocomplete result filtering by stock availability

### DIFF
--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -66,6 +66,7 @@ module Spree
               variants = variants.active
             end
           end
+          variants = variants.in_stock if params[:in_stock_only] || cannot?(:view_out_of_stock, Spree::Variant)
           variants
         end
 

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -89,6 +89,32 @@ module Spree
         end
       end
 
+      context "stock filtering" do
+        subject { api_get :index, in_stock_only: true }
+
+        context "variant is out of stock" do
+          before do
+            variant.stock_items.update_all(count_on_hand: 0)
+          end
+
+          it "is not returned in the results" do
+            subject
+            expect(json_response["variants"].count).to eq 0
+          end
+        end
+
+        context "variant is in stock" do
+          before do
+            variant.stock_items.update_all(count_on_hand: 10)
+          end
+
+          it "is returned in the results" do
+            subject
+            expect(json_response["variants"].count).to eq 1
+          end
+        end
+      end
+
       context "pagination" do
         it "can select the next page of variants" do
           second_variant = create(:variant)

--- a/backend/app/assets/javascripts/spree/backend/orders/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/edit.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
   'use strict';
 
-  $('[data-hook="add_product_name"]').find('.variant_autocomplete').variantAutocomplete();
+  $('[data-hook="add_product_name"]').find('.variant_autocomplete').variantAutocomplete({ in_stock_only: true });
 });

--- a/backend/app/assets/javascripts/spree/backend/stock_transfers/edit.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfers/edit.coffee
@@ -1,6 +1,6 @@
 $(document).ready ->
   if $('#stock-transfer-transfer-items').length > 0
-    Spree.StockTransfers.VariantForm.initializeForm()
+    Spree.StockTransfers.VariantForm.initializeForm(true)
     Spree.StockTransfers.VariantForm.beginListeningForAdd()
     Spree.StockTransfers.CountUpdateForms.beginListening(false)
     Spree.StockTransfers.TransferItemDeleting.beginListening()

--- a/backend/app/assets/javascripts/spree/backend/stock_transfers/receive.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfers/receive.coffee
@@ -1,6 +1,6 @@
 $(document).ready ->
   if $('#received-transfer-items').length > 0
-    Spree.StockTransfers.VariantForm.initializeForm()
+    Spree.StockTransfers.VariantForm.initializeForm(false)
     Spree.StockTransfers.VariantForm.beginListeningForReceive()
     Spree.StockTransfers.CountUpdateForms.beginListening(true)
 

--- a/backend/app/assets/javascripts/spree/backend/stock_transfers/variant_form.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfers/variant_form.coffee
@@ -1,6 +1,6 @@
 class VariantForm
-  @initializeForm: ->
-    autoCompleteEl().variantAutocomplete()
+  @initializeForm: (isBuilding) ->
+    autoCompleteEl().variantAutocomplete({ in_stock_only: isBuilding })
     resetVariantAutocomplete()
 
   @beginListeningForReceive: ->

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee.erb
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee.erb
@@ -10,7 +10,7 @@ formatVariantResult = (variant) ->
   variant.image = variant.images[0].mini_url  if variant["images"][0] isnt `undefined` and variant["images"][0].mini_url isnt `undefined`
   variantTemplate variant: variant
 
-$.fn.variantAutocomplete = ->
+$.fn.variantAutocomplete = (searchOptions = {}) ->
   @select2
     placeholder: Spree.translations.variant_placeholder
     minimumInputLength: 3
@@ -22,9 +22,11 @@ $.fn.variantAutocomplete = ->
       datatype: "json"
       quietMillis: 500
       params: { "headers": { "X-Spree-Token": Spree.api_key } }
-      data: (term, page) ->
-        q:
-          product_name_or_sku_cont: term
+      data: (term, page) =>
+        searchData =
+          q:
+            product_name_or_sku_cont: term
+        _.extend(searchData, searchOptions)
 
       results: (data, page) ->
         window.variants = data["variants"]

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -151,11 +151,12 @@ describe "Order Details", js: true do
           product.master.stock_items.first.update_column(:count_on_hand, 0)
         end
 
-        it "displays out of stock instead of add button" do
-          select2_search product.name, :from => Spree.t(:name_or_sku)
+        it "doesn't display the out of stock variant in the search results" do
+          select2_search_without_selection product.name, from: ".variant_autocomplete"
 
-          within("table.stock-levels") do
-            page.should have_content(0)
+          page.should have_selector('.select2-no-results')
+          within(".select2-no-results") do
+            page.should have_content("NO MATCHES FOUND")
           end
         end
       end

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -64,7 +64,7 @@ module Spree
         can [:index, :read], StockLocation, active: true
         can [:index, :read], Taxon
         can [:index, :read], Taxonomy
-        can [:index, :read], Variant
+        can [:index, :read, :view_out_of_stock], Variant
         can [:index, :read], Zone
       end
 

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -46,6 +46,11 @@ module CapybaraExt
     targetted_select2_search(value, options)
   end
 
+  def select2_search_without_selection(value, options)
+    page.execute_script "$('#{options[:from]}').select2('open');"
+    page.execute_script "$('input.select2-input').val('#{value}').trigger('keyup-change');"
+  end
+
   def targetted_select2_search(value, options)
     page.execute_script %Q{$('#{options[:from]}').select2('open')}
     page.execute_script "$('#{options[:dropdown_css]} input.select2-input').val('#{value}').trigger('keyup-change');"


### PR DESCRIPTION
When creating a stock transfer the variant autocomplete results should filter variants that do not have any stock.
Includes change to only display in stock variants when creating an order in the admin.