### PR TITLE
Returned exchange item should cancel charge of unreturned original item

### DIFF
--- a/core/app/models/spree/calculator/returns/default_refund_amount.rb
+++ b/core/app/models/spree/calculator/returns/default_refund_amount.rb
@@ -9,7 +9,7 @@ module Spree
       end
 
       def compute(return_item)
-        return 0.0.to_d if return_item.exchange_requested?
+        return 0.0.to_d if return_item.part_of_exchange?
         weighted_order_adjustment_amount(return_item.inventory_unit) + weighted_line_item_pre_tax_amount(return_item.inventory_unit)
       end
 

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -2,7 +2,7 @@ module Spree
   class ReturnItem < ActiveRecord::Base
 
     INTERMEDIATE_RECEPTION_STATUSES = %i(given_to_customer lost_in_transit shipped_wrong_item short_shipped in_transit)
-    COMPLETED_RECEPTION_STATUSES = INTERMEDIATE_RECEPTION_STATUSES + [:received]
+    COMPLETED_RECEPTION_STATUSES = INTERMEDIATE_RECEPTION_STATUSES + [:received, :unexchanged]
 
     class_attribute :return_eligibility_validator
     self.return_eligibility_validator = ReturnItem::EligibilityValidator::DefaultEligibilityValidator
@@ -63,11 +63,13 @@ module Spree
 
     state_machine :reception_status, initial: :awaiting do
       after_transition to: COMPLETED_RECEPTION_STATUSES,  do: :attempt_accept
+      after_transition to: COMPLETED_RECEPTION_STATUSES,  do: :check_unexchange
       after_transition to: :received, do: :process_inventory_unit!
 
       event(:cancel) { transition to: :cancelled, from: :awaiting }
 
       event(:receive) { transition to: :received, from: INTERMEDIATE_RECEPTION_STATUSES + [:awaiting] }
+      event(:unexchange) { transition to: :unexchanged, from: [:awaiting] }
       event(:give) { transition to: :given_to_customer, from: :awaiting }
       event(:lost) { transition to: :lost_in_transit, from: :awaiting }
       event(:wrong_item_shipped) { transition to: :shipped_wrong_item, from: :awaiting }
@@ -162,6 +164,12 @@ module Spree
       status_paths.map{ |s| s.to_s.humanize }.zip(event_paths)
     end
 
+    def part_of_exchange?
+      # test whether this ReturnItem was either a) one for which an exchange was sent or
+      #   b) the exchanged item itself being returned in lieu of the original item
+      exchange_requested? || sibling_intended_for_exchange('unexchanged')
+    end
+
     private
 
     def persist_acceptance_status_errors
@@ -186,6 +194,20 @@ module Spree
 
       Spree::StockMovement.create!(stock_item_id: stock_item.id, quantity: 1) if should_restock?
       customer_return.process_return! if customer_return
+    end
+
+    def sibling_intended_for_exchange(status)
+      # This happens when we ship an exchange to a customer, but the customer keeps the original and returns the exchange
+      self.class.find_by(reception_status: status, exchange_inventory_unit: inventory_unit)
+    end
+
+    def check_unexchange
+      original_ri = sibling_intended_for_exchange('awaiting')
+      if original_ri
+        original_ri.unexchange!
+        set_default_pre_tax_amount
+        save!
+      end
     end
 
     # This logic is also present in the customer return. The reason for the

--- a/core/spec/models/spree/promotion_builder_spec.rb
+++ b/core/spec/models/spree/promotion_builder_spec.rb
@@ -91,7 +91,7 @@ describe Spree::PromotionBuilder do
         end
       end
 
-      context "when the builder can build promotion codes", focus: true do
+      context "when the builder can build promotion codes" do
         let(:number_of_codes) { 1 }
 
         it "creates the correct number of codes" do

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -61,4 +61,7 @@ RSpec.configure do |config|
   config.extend WithModel
 
   config.fail_fast = ENV['FAIL_FAST'] || false
+
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
I'm going with a new 'unexchanged' status of the original ReturnItem.
I've added :unexchanged as a COMPLETED_RECEPTION_STATUSES so it won't get picked up with exchanges.rake. No tests fail, and it seems reasonable to be treated like :received, but still needs more brainpower devoted to it.
