### PR TITLE
Don't refresh shipping rates after an order is completed.

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -131,7 +131,7 @@ module Spree
     end
 
     def refresh_rates
-      return shipping_rates if shipped?
+      return shipping_rates if shipped? || order.completed?
       return [] unless can_get_rates?
 
       # StockEstimator.new assigment below will replace the current shipping_method


### PR DESCRIPTION
It seems odd that this would happen, since we would want the total
dollar amount to be set in stone by the time the order gets completed.