### PR TITLE
Order#after_cancel cancels pending and completed payments

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -583,7 +583,7 @@ module Spree
 
       def after_cancel
         shipments.each { |shipment| shipment.cancel! }
-        payments.completed.each { |payment| payment.cancel! }
+        payments.pending_or_completed.each { |payment| payment.cancel! }
 
         send_cancel_email
         self.update_column(:payment_state, 'void') unless shipped?

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -33,6 +33,7 @@ module Spree
     scope :offset_payment, -> { where("source_type = 'Spree::Payment' AND amount < 0 AND state = 'completed'") }
     scope :completed, -> { with_state('completed') }
     scope :pending, -> { with_state('pending') }
+    scope :pending_or_completed, -> { where(state: %w(completed pending)) }
     scope :failed, -> { with_state('failed') }
     scope :valid, -> { where.not(state: %w(failed invalid)) }
 

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -175,7 +175,7 @@ describe Spree::Order do
         let(:payment) { create(:payment) }
 
         it "should automatically refund all payments" do
-          order.stub_chain(:payments, :completed).and_return([payment])
+          order.stub_chain(:payments, :pending_or_completed).and_return([payment])
           payment.should_receive(:cancel!)
           order.contents.cancel
         end


### PR DESCRIPTION
`Payment#cancel!` will void a payment if it has been authorized and refund a payment if it has been captured. Currently `Order#after_cancel` only operates on payments that have been completed (refunds  the captured ones), but we also should release authorizations of pending payments, if there are any.

cc @athal7 @gmacdougall @jhawthorn @cbrunsdon 