### PR TITLE
Prevent inventory units from being created without an associated shipment

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -5,7 +5,7 @@ module Spree
       around_filter :lock_order, only: [:next, :advance, :complete]
       before_filter :update_order_state, only: [:next, :advance]
 
-      rescue_from Spree::LineItem::InsufficientStock, with: :insufficient_stock_for_line_items
+      rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
 
       def next
         authorize! :update, @order, order_token
@@ -65,7 +65,7 @@ module Spree
           @order.total == BigDecimal(expected_total)
         end
 
-        def insufficient_stock_for_line_items(exception)
+        def insufficient_stock_error(exception)
           render json: { errors: [I18n.t(:quantity_is_not_available, :scope => "spree.api.order")], type: 'insufficient_stock' }, status: 422
         end
     end

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -52,7 +52,7 @@ module Spree
 
       context 'insufficient stock' do
         before do
-          expect_any_instance_of(Spree::Order).to receive(:next!).and_raise(Spree::LineItem::InsufficientStock)
+          expect_any_instance_of(Spree::Order).to receive(:next!).and_raise(Spree::Order::InsufficientStock)
         end
 
         subject { api_put :next, :id => order.to_param, :order_token => order.token }

--- a/api/spec/controllers/spree/api/inventory_units_controller_spec.rb
+++ b/api/spec/controllers/spree/api/inventory_units_controller_spec.rb
@@ -11,23 +11,24 @@ module Spree
 
     context "as an admin" do
       sign_in_as_admin!
+      let(:variant) { create(:variant) }
 
       it "gets an inventory unit" do
         api_get :show, :id => @inventory_unit.id
         json_response['state'].should eq @inventory_unit.state
       end
 
-      it "updates an inventory unit (only shipment is accessable by default)" do
+      it "updates an inventory unit" do
         api_put :update, :id => @inventory_unit.id,
-                         :inventory_unit => { :shipment => nil }
-        json_response['shipment_id'].should be_nil
+                         :inventory_unit => { variant_id: variant.id }
+        json_response['variant_id'].should eq variant.id
       end
 
       context 'fires state event' do
         it 'if supplied with :fire param' do
           api_put :update, :id => @inventory_unit.id,
                            :fire => 'ship',
-                           :inventory_unit => { :shipment => nil }
+                           :inventory_unit => { variant_id: variant.id }
 
           json_response['state'].should eq 'shipped'
         end

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -4,7 +4,7 @@ module Spree
       before_filter :initialize_order_events
       before_filter :load_order, :only => [:edit, :update, :advance, :complete, :confirm, :cancel, :resume, :approve, :resend, :open_adjustments, :close_adjustments, :cart]
       around_filter :lock_order, :only => [:update, :advance, :complete, :confirm, :cancel, :resume, :approve, :resend]
-      rescue_from Spree::LineItem::InsufficientStock, with: :insufficient_stock_error
+      rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
 
       respond_to :html
 

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -204,7 +204,7 @@ describe Spree::Admin::OrdersController do
 
       context 'insufficient stock to complete the order' do
         before do
-          order.should_receive(:complete!).and_raise Spree::LineItem::InsufficientStock
+          order.should_receive(:complete!).and_raise Spree::Order::InsufficientStock
         end
 
         it 'messages and redirects' do

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -14,6 +14,8 @@ module Spree
     has_one :original_return_item, class_name: "Spree::ReturnItem", foreign_key: :exchange_inventory_unit_id
     has_one :unit_cancel, class_name: "Spree::UnitCancel"
 
+    validates_presence_of :order, :shipment, :line_item, :variant
+
     before_destroy :ensure_no_return_items
 
     scope :backordered, -> { where state: 'backordered' }

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -1,7 +1,5 @@
 module Spree
   class LineItem < ActiveRecord::Base
-    class InsufficientStock < StandardError; end
-
     before_validation :invalid_quantity_check
     belongs_to :order, class_name: "Spree::Order", inverse_of: :line_items, touch: true
     belongs_to :variant, class_name: "Spree::Variant", inverse_of: :line_items

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -3,6 +3,8 @@ require 'spree/order/checkout'
 
 module Spree
   class Order < ActiveRecord::Base
+    class InsufficientStock < StandardError; end
+
     include Checkout
     include CurrencyUpdater
 
@@ -559,7 +561,7 @@ module Spree
           inventory_validator = Spree::Stock::InventoryValidator.new
 
           errors = line_items.map { |line_item| inventory_validator.validate(line_item) }.compact
-          raise Spree::LineItem::InsufficientStock if errors.any?
+          raise InsufficientStock if errors.any?
         end
       end
 
@@ -567,7 +569,7 @@ module Spree
         availability_validator = Spree::Stock::AvailabilityValidator.new
 
         errors = line_items.map { |line_item| availability_validator.validate(line_item) }.compact
-        raise Spree::LineItem::InsufficientStock if errors.any?
+        raise InsufficientStock if errors.any?
       end
 
       def has_available_shipment

--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -25,6 +25,7 @@ module Spree
             next unless stock_location.stock_item(variant)
 
             on_hand, backordered = stock_location.fill_status(variant, units.count)
+            raise Spree::Order::InsufficientStock unless on_hand > 0 || backordered > 0
             package.add_multiple units.slice!(0, on_hand), :on_hand if on_hand > 0
             package.add_multiple units.slice!(0, backordered), :backordered if backordered > 0
           else

--- a/core/db/migrate/20150528125647_delete_inventory_units_without_shipment.rb
+++ b/core/db/migrate/20150528125647_delete_inventory_units_without_shipment.rb
@@ -7,7 +7,9 @@ class DeleteInventoryUnitsWithoutShipment < ActiveRecord::Migration
     Spree::Order.where(id: order_ids).find_each do |order|
       # Order may not be completed but have shipped
       # shipments if it has a pending unreturned exchange
-      next if order.completed? || order.shipments.any? { |s| s.shipped? }
+      next if order.completed?
+      next if order.canceled?
+      next if order.shipments.any? { |s| s.shipped? || s.ready? || s.canceled? }
       say "Removing inventory units without shipment for order ##{order.number}"
       order.transaction do
         order.inventory_units.destroy_all

--- a/core/db/migrate/20150528125647_delete_inventory_units_without_shipment.rb
+++ b/core/db/migrate/20150528125647_delete_inventory_units_without_shipment.rb
@@ -1,0 +1,23 @@
+class DeleteInventoryUnitsWithoutShipment < ActiveRecord::Migration
+  # Prevent everything from running in one giant transaction in postrgres.
+  disable_ddl_transaction!
+
+  def up
+    order_ids = Spree::InventoryUnit.where(shipment_id: nil).pluck(:order_id).uniq.compact
+    Spree::Order.where(id: order_ids).find_each do |order|
+      # Order may not be completed but have shipped
+      # shipments if it has a pending unreturned exchange
+      next if order.completed? || order.shipments.any? { |s| s.shipped? }
+      say "Removing inventory units without shipment for order ##{order.number}"
+      order.transaction do
+        order.inventory_units.destroy_all
+        order.shipments.destroy_all
+        order.restart_checkout_flow
+      end
+    end
+  end
+
+  def down
+    # intentionally left blank
+  end
+end

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -13,8 +13,8 @@ module Spree
             order = Spree::Order.create!
             order.contents.associate_user(user)
 
-            create_shipments_from_params(params.delete(:shipments_attributes), order)
             create_line_items_from_params(params.delete(:line_items_attributes),order)
+            create_shipments_from_params(params.delete(:shipments_attributes), order)
             create_adjustments_from_params(params.delete(:adjustments_attributes), order)
             create_payments_from_params(params.delete(:payments_attributes), order)
 
@@ -50,6 +50,11 @@ module Spree
               unit = shipment.inventory_units.build
               unit.order = order
               unit.variant_id = iu[:variant_id]
+              if line_item = order.line_items.find_by(variant_id: iu[:variant_id])
+                unit.line_item = line_item
+              else
+                unit.line_item = order.contents.add(Spree::Variant.find(iu[:variant_id]), 1)
+              end
             end
 
             shipment.save!

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -218,7 +218,7 @@ module Spree
         end
 
         it 'ensures variant exists and is not deleted' do
-          Importer::Order.should_receive(:ensure_variant_id_from_params)
+          expect(Importer::Order).to receive(:ensure_variant_id_from_params).and_call_original
           order = Importer::Order.import(user,params)
         end
 

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -335,7 +335,7 @@ describe Spree::Order do
       it "does not allow the order to complete" do
         expect {
           order.complete!
-        }.to raise_error Spree::LineItem::InsufficientStock
+        }.to raise_error Spree::Order::InsufficientStock
 
         expect(order.state).to eq 'confirm'
         expect(order.line_items.first.errors[:quantity]).to be_present
@@ -355,7 +355,7 @@ describe Spree::Order do
       end
 
       it "does not allow order to complete" do
-        expect { order.complete! }.to raise_error Spree::LineItem::InsufficientStock
+        expect { order.complete! }.to raise_error Spree::Order::InsufficientStock
 
         expect(order.state).to eq 'confirm'
         expect(order.line_items.first.errors[:inventory]).to be_present
@@ -394,7 +394,7 @@ describe Spree::Order do
 
         context 'when the exchange is not for an unreturned item' do
           it 'does not allow the order to completed' do
-            expect { order.complete! }.to raise_error  Spree::LineItem::InsufficientStock
+            expect { order.complete! }.to raise_error  Spree::Order::InsufficientStock
           end
         end
       end
@@ -410,7 +410,7 @@ describe Spree::Order do
         order.stub(payment_required?: true)
         order.stub(ensure_available_shipping_rates: true)
         order.line_items << FactoryGirl.create(:line_item)
-        order.line_items.each { |li| li.inventory_units.create! }
+        order.create_proposed_shipments
         Spree::OrderUpdater.new(order).update
 
         order.save!
@@ -442,7 +442,7 @@ describe Spree::Order do
         order.stub(payment_required?: true)
         order.stub(ensure_available_shipping_rates: true)
         order.line_items << FactoryGirl.create(:line_item)
-        order.line_items.each { |li| li.inventory_units.create! }
+        order.create_proposed_shipments
         Spree::OrderUpdater.new(order).update
       end
 

--- a/core/spec/models/spree/stock/packer_spec.rb
+++ b/core/spec/models/spree/stock/packer_spec.rb
@@ -47,6 +47,19 @@ module Spree
           end
         end
 
+        context "not enough on hand and not backorderable" do
+          let(:packer) { Packer.new(stock_location, inventory_units) }
+
+          before do
+            stock_location.stock_items.update_all(backorderable: false)
+            stock_location.stock_items.each { |si| si.set_count_on_hand(0) }
+          end
+
+          it "raises an error" do
+            expect { packer.default_package }.to raise_error Spree::Order::InsufficientStock
+          end
+        end
+
         context "doesn't track inventory levels" do
           let(:variant) { build(:variant) }
           let(:order) { build(:order_with_line_items, line_items_count: 1) }

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -145,7 +145,7 @@ describe Spree::CheckoutController do
           # An order requires a payment to reach the complete state
           # This is because payment_required? is true on the order
           create(:payment, :amount => order.total, :order => order)
-          order.line_items.each {|li| li.inventory_units.create! }
+          order.create_proposed_shipments
           order.payments.reload
         end
 


### PR DESCRIPTION
When using the StockCoordinator to [generate shipments] (https://github.com/bonobos/spree/blob/2-2-dev/core/app/models/spree/order.rb#L438), the InventoryUnitBuilder [associates inventory units to the order] (https://github.com/bonobos/spree/blob/2-2-dev/core/app/models/spree/stock/inventory_unit_builder.rb#L11) which will then get associated to a [shipment] (https://github.com/bonobos/spree/blob/2-2-dev/core/app/models/spree/stock/package.rb#L100). When there isn’t enough stock for a variant, the inventory unit does not get added to a shipment but continues associated to the order. When the order is saved the inventory units will be persisted without having an associated shipment.

Change will raise an error when attempting to create a package for a variant that does not have enough stock. I’ve added `validates_presence_of` validations for all of the associations we’d always want to be present on an inventory unit. I've also moved the InsufficientStock error from the LineItem to the Order to make it reusable for this scenario.

The added migration deletes all of the associated inventory units and shipments for orders that have never been completed and that contain inventory units without an associated shipment. It will also restart the checkout flow for those orders.