### PR TITLE
Remove edit button from closed stock transfer on index page

### DIFF
--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -94,7 +94,7 @@
           <td class="actions">
             <% if stock_transfer.receivable? && can?(:edit, stock_transfer) %>
               <%= link_to_with_icon 'download', Spree.t('actions.receive'), receive_admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'green' } %>
-            <% elsif can?(:edit, stock_transfer) %>
+            <% elsif !stock_transfer.closed? && can?(:edit, stock_transfer) %>
               <%= link_to_with_icon 'edit', Spree.t('actions.edit'), stock_transfer_edit_or_ship_path(stock_transfer), no_text: true, data: { action: 'edit' } %>
             <% elsif can?(:show, stock_transfer) %>
               <%= link_to_with_icon 'eye', Spree.t(:show), admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'green' } %>


### PR DESCRIPTION
Removes the edit button from the stock transfer index page after a stock
transfer has been closed.