### PR TITLE
Correct stock transfer routing for editing

### DIFF
--- a/backend/app/helpers/spree/admin/stock_transfers_helper.rb
+++ b/backend/app/helpers/spree/admin/stock_transfers_helper.rb
@@ -9,6 +9,10 @@ module Spree
         end
       end
 
+      def edit_or_ship_path(stock_transfer)
+        stock_transfer.finalized? ? tracking_info_admin_stock_transfer_path(stock_transfer) : edit_admin_stock_transfer_path(stock_transfer)
+      end
+
       def status(stock_transfer)
         stock_transfer.closed? ? Spree.t(:closed) : Spree.t(:open)
       end

--- a/backend/app/helpers/spree/admin/stock_transfers_helper.rb
+++ b/backend/app/helpers/spree/admin/stock_transfers_helper.rb
@@ -9,11 +9,15 @@ module Spree
         end
       end
 
-      def edit_or_ship_path(stock_transfer)
-        stock_transfer.finalized? ? tracking_info_admin_stock_transfer_path(stock_transfer) : edit_admin_stock_transfer_path(stock_transfer)
+      def stock_transfer_edit_or_ship_path(stock_transfer)
+        if stock_transfer.finalized?
+          tracking_info_admin_stock_transfer_path(stock_transfer)
+        else
+          edit_admin_stock_transfer_path(stock_transfer)
+        end
       end
 
-      def status(stock_transfer)
+      def stock_transfer_status(stock_transfer)
         stock_transfer.closed? ? Spree.t(:closed) : Spree.t(:open)
       end
     end

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -95,7 +95,7 @@
             <% if stock_transfer.receivable? && can?(:edit, stock_transfer) %>
               <%= link_to_with_icon 'download', Spree.t('actions.receive'), receive_admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'green' } %>
             <% elsif can?(:edit, stock_transfer) %>
-              <%= link_to_with_icon 'edit', Spree.t('actions.edit'), edit_admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'edit' } %>
+              <%= link_to_with_icon 'edit', Spree.t('actions.edit'), edit_or_ship_path(stock_transfer), no_text: true, data: { action: 'edit' } %>
             <% elsif can?(:show, stock_transfer) %>
               <%= link_to_with_icon 'eye', Spree.t(:show), admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'green' } %>
             <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -90,12 +90,12 @@
           <td class="align-center"><%= stock_transfer.expected_item_count %></td>
           <td class="align-center"><%= stock_transfer.received_item_count %></td>
           <td><%= stock_transfer.shipped_at.try(:to_date) %></td>
-          <td><%= status(stock_transfer) %></td>
+          <td><%= stock_transfer_status(stock_transfer) %></td>
           <td class="actions">
             <% if stock_transfer.receivable? && can?(:edit, stock_transfer) %>
               <%= link_to_with_icon 'download', Spree.t('actions.receive'), receive_admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'green' } %>
             <% elsif can?(:edit, stock_transfer) %>
-              <%= link_to_with_icon 'edit', Spree.t('actions.edit'), edit_or_ship_path(stock_transfer), no_text: true, data: { action: 'edit' } %>
+              <%= link_to_with_icon 'edit', Spree.t('actions.edit'), stock_transfer_edit_or_ship_path(stock_transfer), no_text: true, data: { action: 'edit' } %>
             <% elsif can?(:show, stock_transfer) %>
               <%= link_to_with_icon 'eye', Spree.t(:show), admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'green' } %>
             <% end %>


### PR DESCRIPTION
Attempting to edit a finalized but unshipped stock transfer will route
to the tracking info page. Editing a stock transfer that has not been
finalized will route to the edit page.