### PR TITLE
Upgrade ActiveMerchant dependency to 1.48.0

### DIFF
--- a/core/spec/models/spree/order_capturing_spec.rb
+++ b/core/spec/models/spree/order_capturing_spec.rb
@@ -102,7 +102,7 @@ describe Spree::OrderCapturing do
 
         class ExceptionallyBogusPaymentMethod < Spree::Gateway::Bogus
           def capture(*args)
-            raise ActiveMerchant::ConnectionError
+            raise ActiveMerchant::ConnectionError.new("foo", nil)
           end
         end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -484,7 +484,7 @@ describe Spree::Payment do
 
       context "when there is an error connecting to the gateway" do
         it "should call gateway_error " do
-          gateway.should_receive(:create_profile).and_raise(ActiveMerchant::ConnectionError)
+          gateway.should_receive(:create_profile).and_raise(ActiveMerchant::ConnectionError.new("foo", nil))
           lambda do
             Spree::Payment.create(
               :amount => 100,

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -140,7 +140,7 @@ describe Spree::Refund do
         payment.payment_method
           .should_receive(:credit)
           .with(amount_in_cents, payment.source, payment.transaction_id, {originator: an_instance_of(Spree::Refund)})
-          .and_raise(ActiveMerchant::ConnectionError)
+          .and_raise(ActiveMerchant::ConnectionError.new("foo", nil))
       end
 
       it 'raises Spree::Core::GatewayError' do

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*', 'vendor/**/*']
   s.require_path = 'lib'
 
-  s.add_dependency 'activemerchant', '~> 1.44.1'
+  s.add_dependency 'activemerchant', '~> 1.48.0'
   s.add_dependency 'acts_as_list', '= 0.3.0'
   s.add_dependency 'awesome_nested_set', '~> 3.0.0.rc.3'
   s.add_dependency 'aws-sdk', '1.27.0'


### PR DESCRIPTION
With this update, ActiveMerchant will capture more types of errors
underneath the scope of ActiveMerchant::ConnectionError, which is the
only exception we rescue during processing. It will also retry any
errors that are retryable.