### PR TITLE
Sort by created at on stocktransfer index page

### DIFF
--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -60,6 +60,7 @@ module Spree
         end
         params[:q].delete(:closed_at_null) unless @show_only_open
         @search = super.ransack(params[:q])
+        @search.sorts = 'created_at desc'
         @search.result.
           page(params[:page]).
           per(params[:per_page] || Spree::Config[:orders_per_page])


### PR DESCRIPTION
Use ransacks sort to sort stock transfers by created at (desc) by
default.