### PR TITLE
Enable the ability to manually mark a processing payment as failed.

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_actions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_actions.scss
@@ -8,7 +8,7 @@ table tbody tr {
       }
     }
 
-    &.action-remove td, &.action-void td {
+    &.action-remove td, &.action-void td, &.action-failure td {
       text-decoration: line-through;
 
       &.actions {

--- a/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
@@ -61,6 +61,8 @@ $color-action-save-bg:           very-light($color-success, 5  ) !default;
 $color-action-save-brd:          very-light($color-success, 20 ) !default;
 $color-action-mail-bg:           very-light($color-success, 5  ) !default;
 $color-action-mail-brd:          very-light($color-success, 20 ) !default;
+$color-action-failure-bg:        very-light($color-error,   10 ) !default;
+$color-action-failure-brd:       very-light($color-error,   20 ) !default;
 
 // Select2 select field colors
 $color-sel-bg:                   $color-3 !default;
@@ -134,21 +136,21 @@ $states: completed, complete, sold, pending, awaiting_return, returned, credit_o
 delivery, payment, confirm, canceled, ready, void, active, inactive, considered_risky, success, notice, error !default;
 
 $states-bg-colors: $color-ste-completed-bg, $color-ste-complete-bg, $color-ste-sold-bg, $color-ste-pending-bg, $color-ste-awaiting_return-bg,
-$color-ste-returned-bg, $color-ste-credit_owed-bg, $color-ste-paid-bg, $color-ste-shipped-bg, $color-ste-balance_due-bg, $color-ste-backorder-bg, 
-$color-ste-checkout-bg, $color-ste-cart-bg, $color-ste-address-bg, $color-ste-delivery-bg, $color-ste-payment-bg, $color-ste-confirm-bg, 
+$color-ste-returned-bg, $color-ste-credit_owed-bg, $color-ste-paid-bg, $color-ste-shipped-bg, $color-ste-balance_due-bg, $color-ste-backorder-bg,
+$color-ste-checkout-bg, $color-ste-cart-bg, $color-ste-address-bg, $color-ste-delivery-bg, $color-ste-payment-bg, $color-ste-confirm-bg,
 $color-ste-canceled-bg, $color-ste-ready-bg, $color-ste-void-bg, $color-ste-active-bg, $color-ste-inactive-bg, $color-ste-considered_risky-bg,
 $color-ste-success-bg, $color-ste-notice-bg, $color-ste-error-bg !default;
 
-$states-text-colors: $color-ste-completed-text, $color-ste-complete-text, $color-ste-sold-text, $color-ste-pending-text, $color-ste-awaiting_return-text, 
-$color-ste-returned-text, $color-ste-credit_owed-text, $color-ste-paid-text, $color-ste-shipped-text, $color-ste-balance_due-text, $color-ste-backorder-text, 
-$color-ste-checkout-text, $color-ste-cart-text, $color-ste-address-text, $color-ste-delivery-text, $color-ste-payment-text, $color-ste-confirm-text, 
+$states-text-colors: $color-ste-completed-text, $color-ste-complete-text, $color-ste-sold-text, $color-ste-pending-text, $color-ste-awaiting_return-text,
+$color-ste-returned-text, $color-ste-credit_owed-text, $color-ste-paid-text, $color-ste-shipped-text, $color-ste-balance_due-text, $color-ste-backorder-text,
+$color-ste-checkout-text, $color-ste-cart-text, $color-ste-address-text, $color-ste-delivery-text, $color-ste-payment-text, $color-ste-confirm-text,
 $color-ste-canceled-text, $color-ste-ready-text, $color-ste-void-text, $color-ste-active-text, $color-ste-inactive-text, $color-ste-considered_risky-text,
 $color-ste-success-text, $color-ste-notice-text, $color-ste-error-text !default;
 
 // Available actions
-$actions: edit, clone, remove, void, capture, save, cancel, mail !default;
-$actions-bg-colors: $color-action-edit-bg, $color-action-clone-bg, $color-action-remove-bg, $color-action-void-bg, $color-action-capture-bg, $color-action-save-bg, $color-action-cancel-bg, $color-action-mail-bg !default;
-$actions-brd-colors: $color-action-edit-brd, $color-action-clone-brd, $color-action-remove-brd, $color-action-void-brd, $color-action-capture-brd, $color-action-save-brd, $color-action-cancel-brd, $color-action-mail-brd !default;
+$actions: edit, clone, remove, void, capture, save, cancel, mail, failure !default;
+$actions-bg-colors: $color-action-edit-bg, $color-action-clone-bg, $color-action-remove-bg, $color-action-void-bg, $color-action-capture-bg, $color-action-save-bg, $color-action-cancel-bg, $color-action-mail-bg, $color-action-failure-bg !default;
+$actions-brd-colors: $color-action-edit-brd, $color-action-clone-brd, $color-action-remove-brd, $color-action-void-brd, $color-action-capture-brd, $color-action-save-brd, $color-action-cancel-brd, $color-action-mail-brd, $color-action-failure-brd !default;
 
 // Sizes
 //--------------------------------------------------------------

--- a/backend/app/assets/stylesheets/spree/backend/shared/_icons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_icons.scss
@@ -22,6 +22,8 @@
 .fa-cancel:before,
 .fa-void:before      { @extend .fa-times:before    }
 
+.fa-failure:before   { @extend .fa-thumbs-down:before }
+
 .fa-trash:before     { @extend .fa-trash-o:before  }
 
 .fa-capture:before   { @extend .fa-check:before    }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -76,7 +76,7 @@ table {
           color: $color-1;
         }
       }
-      .fa-trash:hover, .fa-void:hover {
+      .fa-trash:hover, .fa-void:hover, .fa-failure:hover {
         background-color: $color-error;
         color: $color-1;
       }

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -129,8 +129,9 @@ module Spree
     end
 
     def actions
-      return [] unless payment_source and payment_source.respond_to? :actions
-      payment_source.actions.select { |action| !payment_source.respond_to?("can_#{action}?") or payment_source.send("can_#{action}?", self) }
+      sa = source_actions
+      sa |= ["failure"] if processing?
+      sa
     end
 
     def payment_source
@@ -160,6 +161,11 @@ module Spree
     end
 
     private
+
+      def source_actions
+        return [] unless payment_source and payment_source.respond_to? :actions
+        payment_source.actions.select { |action| !payment_source.respond_to?("can_#{action}?") or payment_source.send("can_#{action}?", self) }
+      end
 
       def validate_source
         if source && !source.valid?

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -712,6 +712,7 @@ en:
     extension: Extension
     existing_shipments: Existing shipments
     failed_payment_attempts: Failed Payment Attempts
+    failure: Failure
     filename: Filename
     fill_in_customer_info: Please fill in customer info
     filter_results: Filter Results

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -792,4 +792,35 @@ describe Spree::Payment do
       ])
     end
   end
+
+  describe "#actions" do
+    let(:source) { Spree::CreditCard.new }
+    before { allow(subject).to receive(:payment_source) { source } }
+
+    it "includes the actions that the source can take" do
+      allow(source).to receive(:can_capture?) { true }
+      expect(subject.actions).to include "capture"
+    end
+
+    it "excludes actions that the source cannot take" do
+      allow(source).to receive(:can_capture?) { false }
+      expect(subject.actions).not_to include "capture"
+    end
+
+    it "does not include 'failure' by default" do
+      expect(subject.actions).not_to include "failure"
+    end
+
+    context "payment state is processing" do
+      it "includes the 'failure' action" do
+        # because the processing state does not provide
+        # clarity about what has happened with an external
+        # payment processor, so we want to allow the ability
+        # to have someone look at the what happened and determine
+        # to mark the payment as having failed
+        subject.state = 'processing'
+        expect(subject.actions).to include "failure"
+      end
+    end
+  end
 end


### PR DESCRIPTION
The 'processing' state for payments can end up being a dead end if the
request to the payment processor fails. It is unclear when that happens
whether the charge has successfully completed, and even if it completed
successfully it does not have the proper information to mark it as a
success. This allows the resolution of payments in the processing state,
by marking them as a failure, and the person digging into the issue can
void the potential charge in the payment processor + create a new
payment here in spree.