### PR TITLE
Handle order capturing rake task failures

### DIFF
--- a/core/app/models/spree/order_capturing.rb
+++ b/core/app/models/spree/order_capturing.rb
@@ -7,6 +7,9 @@ class Spree::OrderCapturing
   class_attribute :void_unused_payments
   self.void_unused_payments = false
 
+  class_attribute :failure_handler
+  self.failure_handler = ->(failures) { raise Spree::OrderCapturingFailures.new(failures.to_json) }
+
   def initialize(order, sorted_payment_method_classes = nil)
     @order = order
     @sorted_payment_method_classes = sorted_payment_method_classes || Spree::OrderCapturing.sorted_payment_method_classes
@@ -42,3 +45,5 @@ class Spree::OrderCapturing
     payments = payments.sort_by { |p| [@sorted_payment_method_classes.index(p.payment_method.class), p.id] }
   end
 end
+
+class Spree::OrderCapturingFailures < StandardError; end

--- a/core/lib/tasks/order_capturing.rake
+++ b/core/lib/tasks/order_capturing.rake
@@ -1,11 +1,23 @@
 namespace :order_capturing do
   desc "Looks for orders with inventory that is fully shipped/short-shipped, and captures money for it"
   task capture_payments: :environment do
+    failures = []
     orders = Spree::Order.complete.where(payment_state: 'balance_due').where('completed_at > ?', Spree::Config[:order_capturing_time_window].days.ago)
+
     orders.find_each do |order|
       if order.inventory_units.all? {|iu| iu.canceled? || iu.shipped? }
-        Spree::OrderCapturing.new(order).capture_payments
+        if Spree::OrderCapturing.failure_handler
+          begin
+            Spree::OrderCapturing.new(order).capture_payments
+          rescue Exception => e
+            failures << { message: "Order #{order.number} unable to capture. #{e.class}: #{e.message}" }
+          end
+        else
+          Spree::OrderCapturing.new(order).capture_payments
+        end
       end
     end
+
+    Spree::OrderCapturing.failure_handler.call(failures) if failures.any?
   end
 end

--- a/core/spec/lib/tasks/order_capturing_spec.rb
+++ b/core/spec/lib/tasks/order_capturing_spec.rb
@@ -21,6 +21,16 @@ describe "order_capturing:capture_payments" do
         expect { subject.invoke }.to change { payment.reload.state }.to('completed')
       }.to change { order.reload.payment_state }.to('paid')
     end
+
+    context "when there is an error capturing payment" do
+      before do
+        Spree::OrderCapturing.any_instance.stub(:capture_payments).and_raise(StateMachine::InvalidTransition)
+      end
+
+      it "raises a OrderCapturingFailures" do
+        expect { subject.invoke }.to raise_error(Spree::OrderCapturingFailures)
+      end
+    end
   end
 
   context "with any inventory not shipped or canceled" do


### PR DESCRIPTION
* Ability to set a failure_handler in your app which you can set to do whatever your app requires
* Catches all exceptions from capturing payments and bubbles it to the handler

cc @athal7 @jhawthorn @gmacdougall 