### PR TITLE
Add inverse_of to stock transfer and transfer items

### DIFF
--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -4,7 +4,7 @@ module Spree
     class InvalidTransferMovement < StandardError; end
 
     has_many :stock_movements, :as => :originator
-    has_many :transfer_items
+    has_many :transfer_items, inverse_of: :stock_transfer
 
     belongs_to :created_by, :class_name => Spree.user_class.to_s
     belongs_to :finalized_by, :class_name => Spree.user_class.to_s

--- a/core/app/models/spree/transfer_item.rb
+++ b/core/app/models/spree/transfer_item.rb
@@ -1,6 +1,6 @@
 module Spree
   class TransferItem < ActiveRecord::Base
-    belongs_to :stock_transfer
+    belongs_to :stock_transfer, inverse_of: :transfer_items
     belongs_to :variant
 
     validate :stock_availability, if: :check_stock?

--- a/core/spec/models/spree/stock_transfer_spec.rb
+++ b/core/spec/models/spree/stock_transfer_spec.rb
@@ -13,6 +13,27 @@ module Spree
     its(:description) { should eq 'PO123' }
     its(:to_param) { should match /T\d+/ }
 
+    describe "transfer item building" do
+      let(:stock_transfer) do
+        variant = source_location.stock_items.first.variant
+        stock_transfer = Spree::StockTransfer.new(
+          number: "T123",
+          source_location: source_location,
+          destination_location: destination_location
+        )
+        stock_transfer.transfer_items.build(variant: variant, expected_quantity: 5)
+        stock_transfer
+      end
+
+      subject { stock_transfer.save }
+
+      it { is_expected.to eq true }
+
+      it "creates the associated transfer item" do
+        expect { subject }.to change { Spree::TransferItem.count }.by(1)
+      end
+    end
+
     describe "#receivable?" do
       subject { stock_transfer.receivable? }
 


### PR DESCRIPTION
The lack of inverse_of was causing the transfer items to not be persisted when being built through the stock transfer.