### PR TITLE
Decrease size of api response when receiving items in a stock transfer

### DIFF
--- a/api/app/controllers/spree/api/stock_transfers_controller.rb
+++ b/api/app/controllers/spree/api/stock_transfers_controller.rb
@@ -5,11 +5,11 @@ module Spree
         authorize! :update, TransferItem
         @stock_transfer = Spree::StockTransfer.accessible_by(current_ability, :update).find_by!(number: params[:id])
         variant = Spree::Variant.accessible_by(current_ability, :show).find(params[:variant_id])
-        transfer_item = @stock_transfer.transfer_items.find_by(variant: variant)
-        if transfer_item.nil?
+        @transfer_item = @stock_transfer.transfer_items.find_by(variant: variant)
+        if @transfer_item.nil?
           render "spree/api/errors/variant_not_in_stock_transfer", status: 422
-        elsif transfer_item.update_attributes(received_quantity: transfer_item.received_quantity + 1)
-          respond_with(@stock_transfer, status: 200, default_template: :show)
+        elsif @transfer_item.update_attributes(received_quantity: @transfer_item.received_quantity + 1)
+          render 'spree/api/stock_transfers/receive', status: 200
         else
           invalid_resource!(@stock_transfer)
         end

--- a/api/app/views/spree/api/stock_transfers/receive.v1.rabl
+++ b/api/app/views/spree/api/stock_transfers/receive.v1.rabl
@@ -1,0 +1,5 @@
+object @stock_transfer
+attributes *stock_transfer_attributes
+node(:received_item) do
+  partial('spree/api/transfer_items/show', object: @transfer_item)
+end

--- a/api/app/views/spree/api/stock_transfers/show.v1.rabl
+++ b/api/app/views/spree/api/stock_transfers/show.v1.rabl
@@ -1,5 +1,0 @@
-object @stock_transfer
-attributes *stock_transfer_attributes
-child :transfer_items => :transfer_items do
-  extends "spree/api/transfer_items/show"
-end

--- a/api/spec/controllers/spree/api/stock_transfers_controller_spec.rb
+++ b/api/spec/controllers/spree/api/stock_transfers_controller_spec.rb
@@ -39,6 +39,11 @@ module Spree
           it "increments the received quantity for the transfer_item" do
             expect { subject }.to change { transfer_item.reload.received_quantity }.by(1)
           end
+
+          it "returns the received transfer item in the response" do
+            subject
+            expect(JSON.parse(response.body)["received_item"]["id"]).to eq transfer_item.id
+          end
         end
 
         context "variant is not in the transfer order" do

--- a/backend/app/assets/javascripts/spree/backend/stock_transfers/stock_transfer.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfers/stock_transfer.coffee
@@ -3,11 +3,6 @@ class StockTransfer
     @number = options.number
     @transferItems = options.transferItems
 
-  findTransferItemByVariantId: (variantId) ->
-    _.find(@transferItems, (transferItem) =>
-      transferItem.variant.id is variantId
-    )
-
   receive: (variantId, successHandler, errorHandler) ->
     Spree.ajax
       url: Spree.routes.receive_stock_transfer_api(@number)

--- a/backend/app/assets/javascripts/spree/backend/stock_transfers/variant_form.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfers/variant_form.coffee
@@ -67,11 +67,11 @@ class VariantForm
     show_flash('success', Spree.translations.updated_successfully)
 
   receiveSuccessHandler = (stockTransfer, variantId) =>
-    stockTransfer = new Spree.StockTransfer
-      number: stockTransfer.number
-      transferItems: stockTransfer.transfer_items
-    transferItem = stockTransfer.findTransferItemByVariantId(variantId)
-    successHandler(transferItem, variantId, true)
+    receivedItem =
+      id: stockTransfer.received_item.id
+      variant: stockTransfer.received_item.variant
+      received_quantity: stockTransfer.received_item.received_quantity
+    successHandler(receivedItem, true)
     Spree.StockTransfers.ReceivedCounter.updateTotal()
     show_flash('success', Spree.translations.received_successfully)
 


### PR DESCRIPTION
The previous response would include all of the stock transfer’s transfer items. This change will only return the transfer item that was received.

Besides being a lot more performant, the change has the added benefit of not exposing a stock transfer’s transfer items unnecessarily.