### PR TITLE
Prevent negative stock transfers from stock admin.

### DIFF
--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -73,6 +73,9 @@ module Spree
       end
 
       def adjust_stock_item_count_on_hand(count_on_hand_adjustment)
+        if @stock_item.count_on_hand + count_on_hand_adjustment < 0
+          raise StockLocation::InvalidMovementError.new(Spree.t(:stock_not_below_zero))
+        end
         @stock_movement = @stock_location.move(@stock_item.variant, count_on_hand_adjustment, current_api_user)
         @stock_item = @stock_movement.stock_item
       end

--- a/api/spec/controllers/spree/api/stock_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/stock_items_controller_spec.rb
@@ -116,12 +116,13 @@ module Spree
           StockItem.delete_all
           variant
         end
+        let(:count_on_hand) { '20' }
         let(:params) do
           {
             stock_location_id: stock_location.to_param,
             stock_item: {
               variant_id: variant.id,
-              count_on_hand: '20'
+              count_on_hand: count_on_hand
             }
           }
         end
@@ -160,6 +161,17 @@ module Spree
             expect(assigns(:stock_item).count_on_hand).to eq 0
           end
         end
+
+        context "attempting to set negative inventory" do
+          let(:count_on_hand) { '-1' }
+
+          it "does not allow negative inventory for the stock item" do
+            subject
+            expect(response.status).to eq 422
+            expect(response.body).to match Spree.t(:stock_not_below_zero)
+            expect(assigns(:stock_item).count_on_hand).to eq 0
+          end
+        end
       end
 
       context 'updating a stock item' do
@@ -170,11 +182,12 @@ module Spree
         subject { api_put :update, params }
 
         context 'adjusting count_on_hand' do
+          let(:count_on_hand) { 40 }
           let(:params) do
             {
               id: stock_item.to_param,
               stock_item: {
-                count_on_hand: 40,
+                count_on_hand: count_on_hand,
                 backorderable: true
               }
             }
@@ -213,14 +226,26 @@ module Spree
               expect(assigns(:stock_item).count_on_hand).to eq 10
             end
           end
+
+          context "attempting to set negative inventory" do
+            let(:count_on_hand) { '-11' }
+
+            it "does not allow negative inventory for the stock item" do
+              subject
+              expect(response.status).to eq 422
+              expect(response.body).to match Spree.t(:stock_not_below_zero)
+              expect(assigns(:stock_item).count_on_hand).to eq 10
+            end
+          end
         end
 
         context 'setting count_on_hand' do
+          let(:count_on_hand) { 40 }
           let(:params) do
             {
               id: stock_item.to_param,
               stock_item: {
-                count_on_hand: 40,
+                count_on_hand: count_on_hand,
                 force: true,
               }
             }
@@ -255,6 +280,17 @@ module Spree
 
             it "doesn't update the stock item's count_on_hand" do
               subject
+              expect(assigns(:stock_item).count_on_hand).to eq 10
+            end
+          end
+
+          context "attempting to set negative inventory" do
+            let(:count_on_hand) { '-1' }
+
+            it "does not allow negative inventory for the stock item" do
+              subject
+              expect(response.status).to eq 422
+              expect(response.body).to match Spree.t(:stock_not_below_zero)
               expect(assigns(:stock_item).count_on_hand).to eq 10
             end
           end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1324,6 +1324,7 @@ en:
     stock_management_requires_a_stock_location: Please create a stock location in order to manage stock.
     stock_movements: Stock Movements
     stock_movements_for_stock_location: Stock Movements for %{stock_location_name}
+    stock_not_below_zero: Stock must not be below zero.
     stock_successfully_transferred: Stock was successfully transferred between locations.
     stock_transfer: Stock Transfer
     stock_transfer_cannot_be_finalized: Stock transfer cannot be finalized


### PR DESCRIPTION
Stock items should only go into negative count on hand when accepting a
backorder order, admins should only be able to reduce stock counts down
to 0, but not below 0.