### PR TITLE
Allow 'unexchanged' ReturnItem to ultimately be returned too

### DIFF
--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -33,7 +33,7 @@ module Spree
     scope :awaiting_return, -> { where(reception_status: 'awaiting') }
     scope :expecting_return, -> { where.not(reception_status: COMPLETED_RECEPTION_STATUSES) }
     scope :not_cancelled, -> { where.not(reception_status: 'cancelled') }
-    scope :valid, -> { where.not(reception_status: %w(cancelled expired))}
+    scope :valid, -> { where.not(reception_status: %w(cancelled expired unexchanged))}
     scope :not_expired, -> { where.not(reception_status: 'expired')}
     scope :received, -> { where(reception_status: 'received') }
     INTERMEDIATE_RECEPTION_STATUSES.each do |reception_status|


### PR DESCRIPTION
This fixes the StateMachine::InvalidTransition bug about calling
:receive from :unexchanged state

This represents a case when the customer asked for an exchange, and
ultimately ended up returning both the exchange and the original.
Perhaps even in the same box, but we processed the exchange item first.