### PR TITLE
Fix OrderCapturing race-condition on payment capturing

### DIFF
--- a/core/app/models/spree/order_capturing.rb
+++ b/core/app/models/spree/order_capturing.rb
@@ -19,7 +19,7 @@ class Spree::OrderCapturing
     return if @order.paid?
 
     Spree::OrderMutex.with_lock!(@order) do
-      uncaptured_amount = @order.display_total.cents
+      uncaptured_amount = @order.reload.display_total.cents
 
       begin
         sorted_payments(@order).each do |payment|


### PR DESCRIPTION
Currently, if X amount of time passes between the initialization of the OrderCapturing object and calling `#capture_payments`, there is a chance that we are dealing with out of date order totals. This solution will pull the most up-to-date totals after we have acquired a lock on the order, so as to make sure we are definitely charging the correct amount regardless of timing.

cc @athal7 @jhawthorn @cbrunsdon @gmacdougall 