### PR TITLE
further refinements to behavior of unexchanged state

### DIFF
--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -2,7 +2,7 @@ module Spree
   class ReturnItem < ActiveRecord::Base
 
     INTERMEDIATE_RECEPTION_STATUSES = %i(given_to_customer lost_in_transit shipped_wrong_item short_shipped in_transit)
-    COMPLETED_RECEPTION_STATUSES = INTERMEDIATE_RECEPTION_STATUSES + [:received, :unexchanged]
+    COMPLETED_RECEPTION_STATUSES = INTERMEDIATE_RECEPTION_STATUSES + [:received]
 
     class_attribute :return_eligibility_validator
     self.return_eligibility_validator = ReturnItem::EligibilityValidator::DefaultEligibilityValidator
@@ -158,8 +158,10 @@ module Spree
       event_paths = reception_status_paths.events
       status_paths.delete(:cancelled)
       status_paths.delete(:expired)
+      status_paths.delete(:unexchanged)
       event_paths.delete(:cancel)
       event_paths.delete(:expired)
+      event_paths.delete(:unexchange)
 
       status_paths.map{ |s| s.to_s.humanize }.zip(event_paths)
     end

--- a/core/app/models/spree/return_item/eligibility_validator/no_reimbursements.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/no_reimbursements.rb
@@ -1,7 +1,7 @@
 module Spree
   class ReturnItem::EligibilityValidator::NoReimbursements < Spree::ReturnItem::EligibilityValidator::BaseValidator
     def eligible_for_return?
-      if @return_item.inventory_unit.return_items.reimbursed.not_expired.any?
+      if @return_item.inventory_unit.return_items.reimbursed.valid.any?
         add_error(:inventory_unit_reimbursed, Spree.t('return_item_inventory_unit_reimbursed'))
         return false
       else

--- a/core/spec/models/spree/return_item/eligibility_validator/no_reimbursements_spec.rb
+++ b/core/spec/models/spree/return_item/eligibility_validator/no_reimbursements_spec.rb
@@ -27,6 +27,22 @@ describe Spree::ReturnItem::EligibilityValidator::NoReimbursements do
           expect(subject).to eq true
         end
       end
+
+      context "but the return item has been canceled" do
+        before { return_item.cancel }
+
+        it "returns true" do
+          expect(subject).to eq true
+        end
+      end
+
+      context "but the return item has been unexchanged" do
+        before { return_item.unexchange }
+
+        it "returns true" do
+          expect(subject).to eq true
+        end
+      end
     end
 
     context "inventory unit has not been reimbursed" do


### PR DESCRIPTION
Let's make 'unexchanged' mostly behave like 'expired' as far as what collections it does or does not appear within.

This is a bug fix to the earlier work on 'unexchanged' returns I did. In this case, a customer returned the exchange item, then returned the original and the validator didn't allow creation of the a ReturnItem.