### PR TITLE
Fixes incorrect variant images being displayed in stock management

### DIFF
--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -32,7 +32,7 @@
         <td class="align-center no-padding" rowspan="<%= row_count %>">
           <div class='variant-container'>
             <div class='variant-image'>
-              <%= small_image variant %>
+              <%= image_tag(variant.display_image.attachment(:small)) %>
             </div>
             <div class='variant-details'>
               <table class='stock-variant-field-table'>

--- a/backend/app/views/spree/admin/stock_transfers/_transfer_item_table.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/_transfer_item_table.html.erb
@@ -22,7 +22,7 @@
           <td class="align-center no-padding">
             <div class='variant-container' data-variant-id="<%= variant.id %>">
               <div class='variant-image'>
-                <%= small_image variant %>
+                <%= image_tag(variant.display_image.attachment(:small)) %>
               </div>
               <div class='variant-details'>
                 <table class='stock-variant-field-table'>

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -177,6 +177,7 @@ module Spree
 
     def define_image_method(style)
       self.class.send :define_method, "#{style}_image" do |product, *options|
+        ActiveSupport::Deprecation.warn "Spree image helpers will be deprecated in the near future. Use the provided resource to access the intendend image directly."
         options = options.first || {}
         if product.images.empty?
           if !product.is_a?(Spree::Variant) && !product.variant_images.empty?

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -6,6 +6,7 @@ module Spree
     has_attached_file :attachment,
                       styles: { mini: '48x48>', small: '100x100>', product: '240x240>', large: '600x600>' },
                       default_style: :product,
+                      default_url: 'noimage/:style.png',
                       url: '/spree/products/:id/:style/:basename.:extension',
                       path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',
                       convert_options: { all: '-strip -auto-orient -colorspace sRGB' }

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -179,6 +179,10 @@ module Spree
       self.track_inventory? && Spree::Config.track_inventory_levels
     end
 
+    def display_image
+      images.first || Spree::Image.new
+    end
+
     private
       # strips all non-price-like characters from the price, taking into account locale settings
       def parse_price(price)

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -442,4 +442,28 @@ describe Spree::Variant do
       expect(Spree::Variant.in_stock).to eq [in_stock_variant]
     end
   end
+
+  describe "#display_image" do
+    subject { variant.display_image }
+
+    context "variant has associated images" do
+      let(:attachment) { File.open(File.expand_path('../../../fixtures/thinking-cat.jpg', __FILE__)) }
+      let(:image_params) { { viewable_id: variant.id, viewable_type: 'Spree::Variant', attachment: attachment, alt: "position 1", position: 1 } }
+      let!(:first_image) { Spree::Image.create(image_params) }
+      let!(:second_image) { image_params.merge(alt: "position 2", position: 2) }
+
+      it "returns the first image" do
+        expect(subject).to eq first_image
+      end
+    end
+
+    context "variant does not have any associated images" do
+      it "returns an image" do
+        expect(subject).to be_a(Spree::Image)
+      end
+      it "returns unpersisted record" do
+        expect(subject).to be_new_record
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently when a variant is supplied to one of the generated image helpers and the variant does not have any associated images, the first of the variant’s product’s variant_images is used. The result is that incorrect images are displayed for certain variants. This can be misleading to admins since the image isn’t incorrect, it’s just not present.

This change is the initial step to begin deprecating the image helper methods. The image helpers’ behavior isn’t very clear so we want to move towards deprecating them in favor of accessing the images associated with a resource directly. A deprecation warning was added to the currently generated helper methods.