### PR TITLE
Be more strict about when inventory units and shipments are allowed to be destroyed.

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -67,7 +67,6 @@ module Spree
         quantity = params[:quantity].to_i
 
         @shipment.order.contents.add(variant, quantity, nil, @shipment)
-
         respond_with(@shipment, default_template: :show)
       end
 
@@ -75,9 +74,14 @@ module Spree
         variant = Spree::Variant.find(params[:variant_id])
         quantity = params[:quantity].to_i
 
-        @shipment.order.contents.remove(variant, quantity, @shipment)
-        @shipment.reload if @shipment.persisted?
-        respond_with(@shipment, default_template: :show)
+        if @shipment.pending?
+          @shipment.order.contents.remove(variant, quantity, @shipment)
+          @shipment.reload if @shipment.persisted?
+          respond_with(@shipment, default_template: :show)
+        else
+          @shipment.errors.add(:base, :cannot_remove_items_shipment_state, state: @shipment.state)
+          invalid_resource!(@shipment)
+        end
       end
 
       def transfer_to_location

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -32,7 +32,7 @@ describe "Customer Details" do
     it "associates a user when not using guest checkout" do
       click_link "Orders"
       click_link "New Order"
-      click_link "Customer Details" 
+      click_link "Customer Details"
       targetted_select2 "foobar@example.com", :from => "#s2id_customer_search"
       fill_in_address
       check "order_use_billing"
@@ -54,6 +54,7 @@ describe "Customer Details" do
         end
 
         click_button "Update"
+        click_link "Customer Details"
         find_field("order_bill_address_attributes_state_name").value.should == "Piaui"
       end
     end
@@ -104,6 +105,7 @@ describe "Customer Details" do
   end
 
   it "should show validation errors" do
+    order.update_attributes!(ship_address_id: nil)
     click_link "Customer Details"
     click_button "Update"
     page.should have_content("Shipping address first name can't be blank")

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -2,22 +2,16 @@
 require 'spec_helper'
 
 describe "Order Details", js: true do
-  let!(:stock_location) { create(:stock_location_with_items) }
   let!(:product) { create(:product, :name => 'spree t-shirt', :price => 20.00) }
   let!(:tote) { create(:product, :name => "Tote", :price => 15.00) }
-  let(:order) { create(:order, :state => 'complete', :completed_at => "2011-02-01 12:36:15", :number => "R100") }
-  let(:state) { create(:state) }
-  #let(:shipment) { create(:shipment, :order => order, :stock_location => stock_location) }
-  let!(:shipping_method) { create(:shipping_method, :name => "Default") }
+  let(:order) { create(:order) } #, :state => 'complete', :completed_at => "2011-02-01 12:36:15", :number => "R100") }
+  let!(:stock_location) { Spree::StockLocation.first_or_create!(name: 'default') }
+  let!(:shipping_method) { create(:free_shipping_method, name: 'Default') }
 
-  before do
-    order.shipments.create(stock_location_id: stock_location.id)
-    order.contents.add(product.master, 2)
-  end
+  before { order.contents.add(product.master, 2) }
 
   context 'as Admin' do
     stub_authorization!
-
 
     context "cart edit page" do
       before do
@@ -30,6 +24,7 @@ describe "Order Details", js: true do
         page.should have_content("spree t-shirt")
         page.should have_content("$40.00")
 
+
         within_row(1) do
           click_icon :edit
           fill_in "quantity", :with => "1"
@@ -41,7 +36,7 @@ describe "Order Details", js: true do
         end
       end
 
-      it "can add an item to a shipment" do
+      it "can add an item to the order" do
         select2_search "spree t-shirt", :from => Spree.t(:name_or_sku)
         within("table.stock-levels") do
           fill_in "quantity_0", :with => 2
@@ -55,7 +50,7 @@ describe "Order Details", js: true do
         end
       end
 
-      it "can remove an item from a shipment" do
+      it "can remove an item from the order" do
         page.should have_content("spree t-shirt")
 
         within_row(1) do
@@ -69,7 +64,7 @@ describe "Order Details", js: true do
       end
 
       # Regression test for #3862
-      it "can cancel removing an item from a shipment" do
+      it "can cancel removing an item from the order" do
         page.should have_content("spree t-shirt")
 
         within_row(1) do
@@ -82,45 +77,8 @@ describe "Order Details", js: true do
         page.should have_content("spree t-shirt")
       end
 
-      it "can add tracking information" do
-        visit spree.edit_admin_order_path(order)
-
-        within(".show-tracking") do
-          click_icon :edit
-        end
-        fill_in "tracking", :with => "FOOBAR"
-        click_icon :check
-
-        page.should_not have_css("input[name=tracking]")
-        page.should have_content("Tracking: FOOBAR")
-      end
-
-      it "can change the shipping method" do
-        order = create(:completed_order_with_totals)
-        visit spree.edit_admin_order_path(order)
-        within("table.index tr.show-method") do
-          click_icon :edit
-        end
-        select2 "Default", :from => "Shipping Method"
-        click_icon :check
-
-        page.should_not have_css('#selected_shipping_rate_id')
-        page.should have_content("Default")
-      end
-
-      it "will show the variant sku" do
-        order = create(:completed_order_with_totals)
-        visit spree.edit_admin_order_path(order)
-        sku = order.line_items.first.variant.sku
-        expect(page).to have_content("SKU: #{sku}")
-      end
-
-      context "with special_instructions present" do
-        let(:order) { create(:order, :state => 'complete', :completed_at => "2011-02-01 12:36:15", :number => "R100", :special_instructions => "Very special instructions here") }
-        it "will show the special_instructions" do
-          visit spree.edit_admin_order_path(order)
-          expect(page).to have_content("Very special instructions here")
-        end
+      it "shows the variant sku" do
+        expect(page).to have_content("SKU: #{product.master.sku}")
       end
 
       context "variant doesn't track inventory" do
@@ -170,14 +128,41 @@ describe "Order Details", js: true do
         product.master.stock_items.first.update_column(:backorderable, true)
         product.master.stock_items.first.update_column(:count_on_hand, 100)
         product.master.stock_items.last.update_column(:count_on_hand, 100)
+        order.contents.advance
+        visit spree.edit_admin_order_path(order)
+      end
+
+      it "can add tracking information" do
+        within(".show-tracking") do
+          click_icon :edit
+        end
+        fill_in "tracking", :with => "FOOBAR"
+        click_icon :check
+
+        page.should_not have_css("input[name=tracking]")
+        page.should have_content("Tracking: FOOBAR")
+      end
+
+      it "can change the shipping method" do
+        within("table.index tr.show-method") do
+          click_icon :edit
+        end
+        select2 "Default", :from => "Shipping Method"
+        click_icon :check
+
+        page.should_not have_css('#selected_shipping_rate_id')
+        page.should have_content("Default")
+      end
+
+      context "with special_instructions present" do
+        it "will show the special_instructions" do
+          order = create(:shipped_order, special_instructions: "Very special instructions here")
+          visit spree.edit_admin_order_path(order)
+          expect(page).to have_content("Very special instructions here")
+        end
       end
 
       context 'splitting to location' do
-        before { visit spree.edit_admin_order_path(order) }
-        # can not properly implement until poltergeist supports checking alert text
-        # see https://github.com/teampoltergeist/poltergeist/pull/516
-        it 'should warn you if you have not selected a location or shipment'
-
         context 'there is enough stock at the other location' do
           it 'should allow me to make a split' do
             order.shipments.count.should == 1
@@ -196,8 +181,6 @@ describe "Order Details", js: true do
           end
 
           it 'should allow me to make a transfer via splitting off all stock' do
-            order.shipments.first.stock_location.id.should == stock_location.id
-
             within_row(1) { click_icon 'arrows-h' }
             targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 2
@@ -205,15 +188,14 @@ describe "Order Details", js: true do
 
             wait_for_ajax
 
+            order.reload
             order.shipments.count.should == 1
-            order.shipments.last.backordered?.should == false
+            order.shipments.first.backordered?.should == false
             order.shipments.first.inventory_units_for(product.master).count.should == 2
             order.shipments.first.stock_location.id.should == stock_location2.id
           end
 
           it 'should allow me to split more than I have if available there' do
-            order.shipments.first.stock_location.id.should == stock_location.id
-
             within_row(1) { click_icon 'arrows-h' }
             targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 5
@@ -221,15 +203,14 @@ describe "Order Details", js: true do
 
             wait_for_ajax
 
+            order.reload
             order.shipments.count.should == 1
-            order.shipments.last.backordered?.should == false
+            order.shipments.first.backordered?.should == false
             order.shipments.first.inventory_units_for(product.master).count.should == 5
             order.shipments.first.stock_location.id.should == stock_location2.id
           end
 
           it 'should not split anything if the input quantity is garbage' do
-            order.shipments.first.stock_location.id.should == stock_location.id
-
             within_row(1) { click_icon 'arrows-h' }
             targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 'ff'
@@ -237,14 +218,13 @@ describe "Order Details", js: true do
 
             wait_for_ajax
 
+            order.reload
             order.shipments.count.should == 1
             order.shipments.first.inventory_units_for(product.master).count.should == 2
             order.shipments.first.stock_location.id.should == stock_location.id
           end
 
           it 'should not allow less than or equal to zero qty' do
-            order.shipments.first.stock_location.id.should == stock_location.id
-
             within_row(1) { click_icon 'arrows-h' }
             targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 0
@@ -252,6 +232,7 @@ describe "Order Details", js: true do
 
             wait_for_ajax
 
+            order.reload
             order.shipments.count.should == 1
             order.shipments.first.inventory_units_for(product.master).count.should == 2
             order.shipments.first.stock_location.id.should == stock_location.id
@@ -262,6 +243,7 @@ describe "Order Details", js: true do
 
             wait_for_ajax
 
+            order.reload
             order.shipments.count.should == 1
             order.shipments.first.inventory_units_for(product.master).count.should == 2
             order.shipments.first.stock_location.id.should == stock_location.id
@@ -270,11 +252,8 @@ describe "Order Details", js: true do
           context 'A shipment has shipped' do
 
             it 'should not show or let me back to the cart page, nor show the shipment edit buttons' do
-              order = create(:order, :state => 'payment', :number => "R100")
-              order.shipments.create!(stock_location_id: stock_location.id, state: 'shipped')
-
-              visit spree.cart_admin_order_path(order)
-
+              order = create(:shipped_order)
+              visit spree.edit_admin_order_path(order)
               page.current_path.should == spree.edit_admin_order_path(order)
               page.should_not have_text 'Cart'
               page.should_not have_selector('.fa-arrows-h')
@@ -316,6 +295,7 @@ describe "Order Details", js: true do
 
               wait_for_ajax
 
+              order.reload
               order.shipments.count.should == 1
               order.shipments.first.inventory_units_for(product.master).count.should == 2
               order.shipments.first.stock_location.id.should == stock_location2.id
@@ -325,10 +305,6 @@ describe "Order Details", js: true do
 
         context 'multiple items in cart' do
           it 'should have no problem splitting if multiple items are in the from shipment' do
-            order.contents.add(create(:variant), 2)
-            order.shipments.count.should == 1
-            order.shipments.first.manifest.count.should == 2
-
             within_row(1) { click_icon 'arrows-h' }
             targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
             click_icon :check

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -38,7 +38,7 @@ describe "Shipments" do
   end
 
   context "moving variants between shipments", js: true do
-    let!(:order) { create(:order_ready_to_ship, :number => "R100", :state => "complete", :line_items_count => 5) }
+    let!(:order) { create(:completed_order_with_pending_payment, :number => "R100", :state => "complete", :line_items_count => 5) }
     let!(:la) { create(:stock_location, name: "LA") }
     before(:each) do
       visit spree.admin_path

--- a/core/app/models/spree/carton.rb
+++ b/core/app/models/spree/carton.rb
@@ -3,7 +3,7 @@ class Spree::Carton < ActiveRecord::Base
   belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :cartons
   belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :cartons
 
-  has_many :inventory_units, inverse_of: :carton
+  has_many :inventory_units, class_name: "Spree::InventoryUnit", inverse_of: :carton, dependent: :nullify
   has_many :orders, -> { uniq }, through: :inventory_units
   has_many :shipments, -> { uniq }, through: :inventory_units
 

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -16,7 +16,7 @@ module Spree
 
     validates_presence_of :order, :shipment, :line_item, :variant
 
-    before_destroy :ensure_no_return_items
+    before_destroy :ensure_can_destroy
 
     scope :backordered, -> { where state: 'backordered' }
     scope :on_hand, -> { where state: 'on_hand' }
@@ -127,11 +127,15 @@ module Spree
         return_items.not_cancelled.first
       end
 
-      # If an inventory unit is associated with return items and really needs
-      # to be deleted then explicitly delete the associated return items first.
-      def ensure_no_return_items
-        if return_items.exists?
-          raise "Inventory units associated with return items should not be deleted."
+      def ensure_can_destroy
+        if !backordered? && !on_hand?
+          errors.add(:state, :cannot_destroy, state: self.state)
+          return false
+        end
+
+        unless shipment.pending?
+          errors.add(:base, :cannot_destroy_shipment_state, state: shipment.state)
+          return false
         end
       end
   end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -4,6 +4,7 @@ require 'spree/order/checkout'
 module Spree
   class Order < ActiveRecord::Base
     class InsufficientStock < StandardError; end
+    class CannotRebuildShipments < StandardError; end
 
     include Checkout
     include CurrencyUpdater
@@ -438,9 +439,14 @@ module Spree
     end
 
     def create_proposed_shipments
-      adjustments.shipping.delete_all
-      shipments.destroy_all
-      self.shipments = Spree::Stock::Coordinator.new(self).shipments
+      if completed?
+        raise CannotRebuildShipments.new(Spree.t(:cannot_rebuild_shipments_order_completed))
+      elsif shipments.any? { |s| !s.pending? }
+        raise CannotRebuildShipments.new(Spree.t(:cannot_rebuild_shipments_shipments_not_pending))
+      else
+        shipments.destroy_all
+        self.shipments = Spree::Stock::Coordinator.new(self).shipments
+      end
     end
 
     def apply_free_shipping_promotions
@@ -456,7 +462,7 @@ module Spree
     # to delivery again so that proper updated shipments are created.
     # e.g. customer goes back from payment step and changes order items
     def ensure_updated_shipments
-      unless completed?
+      if !completed? && shipments.all?(&:pending?)
         self.shipments.destroy_all
         self.update_column(:shipment_total, 0)
       end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -17,6 +17,8 @@ module Spree
 
     before_validation :set_cost_zero_when_nil
 
+    before_destroy :ensure_can_destroy
+
     # TODO remove the suppress_mailer temporary variable once we are calling 'ship'
     # from outside of the state machine and can actually pass variables through.
     attr_accessor :special_instructions, :suppress_mailer
@@ -395,6 +397,13 @@ module Spree
 
       def can_get_rates?
         order.ship_address && order.ship_address.valid?
+      end
+
+      def ensure_can_destroy
+        unless pending?
+          errors.add(:state, :cannot_destroy, state: self.state)
+          return false
+        end
       end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -274,6 +274,12 @@ en:
           attributes:
             base:
               card_expired: "Card has expired"
+        spree/inventory_unit:
+          attributes:
+            state:
+              cannot_destroy: "Cannot destroy a %{state} inventory unit"
+            base:
+              cannot_destroy_shipment_state: "Cannot destroy an inventory unit for a %{state} shipment"
         spree/line_item:
           attributes:
             currency:
@@ -292,6 +298,12 @@ en:
               cannot_be_associated_unless_accepted: cannot be associated to a return item that is not accepted.
             inventory_unit:
               other_completed_return_item_exists: "%{inventory_unit_id} has already been taken by return item %{return_item_id}"
+        spree/shipment:
+          attributes:
+            state:
+              cannot_destroy: "Cannot destroy a %{state} shipment"
+            base:
+              cannot_remove_items_shipment_state: "Cannot remove items from a %{state} shipment"
 
   devise:
     confirmations:
@@ -511,6 +523,8 @@ en:
     cancel_inventory: 'Cancel Inventory'
     cannot_create_payment_without_payment_methods: You cannot create a payment for an order without any payment methods defined.
     cannot_create_returns: Cannot create returns as this order has no shipped units.
+    cannot_rebuild_shipments_order_completed: Cannot rebuild shipments for a completed order.
+    cannot_rebuild_shipments_shipments_not_pending: Cannot rebuild shipments for an order with non-pending shipments.
     cannot_perform_operation: Cannot perform requested operation
     cannot_set_shipping_method_without_address: Cannot set shipping method until customer details are provided.
     capture: Capture

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :order, class: Spree::Order do
     user
     bill_address
+    ship_address
     completed_at nil
     email { user.email }
 
@@ -61,10 +62,22 @@ FactoryGirl.define do
             order.reload
           end
           factory :shipped_order do
-            after(:create) do |order|
+            transient do
+              with_cartons true
+            end
+            after(:create) do |order, evaluator|
               order.shipments.each do |shipment|
                 shipment.inventory_units.each { |u| u.update_column('state', 'shipped') }
                 shipment.update_columns(state: 'shipped', shipped_at: Time.now)
+                if evaluator.with_cartons
+                  Spree::Carton.create!(
+                    stock_location: shipment.stock_location,
+                    address: shipment.address,
+                    shipping_method: shipment.shipping_method,
+                    inventory_units: shipment.inventory_units,
+                    shipped_at: Time.now,
+                  )
+                end
               end
               order.reload
             end

--- a/core/spec/lib/tasks/migrations/copy_shipped_shipments_to_cartons_spec.rb
+++ b/core/spec/lib/tasks/migrations/copy_shipped_shipments_to_cartons_spec.rb
@@ -24,7 +24,7 @@ describe 'spree:migrations:copy_shipped_shipments_to_cartons' do
       shipped_and_cartonized_order.shipments.first
     end
 
-    let(:shipped_order) { create(:shipped_order, line_items_count: 1) }
+    let(:shipped_order) { create(:shipped_order, line_items_count: 1, with_cartons: false) }
 
     let(:shipped_order_without_units) do
       create(:shipped_order, line_items_count: 1) do |order|
@@ -70,7 +70,7 @@ describe 'spree:migrations:copy_shipped_shipments_to_cartons' do
 
       let!(:second_shipped_shipment) { second_shipped_order.shipments.first }
 
-      let(:second_shipped_order) { create(:shipped_order, line_items_count: 1) }
+      let(:second_shipped_order) { create(:shipped_order, line_items_count: 1, with_cartons: false) }
 
       it 'creates only a carton for the second shipment' do
         expect {

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -250,4 +250,46 @@ describe Spree::InventoryUnit do
       it { should eq false }
     end
   end
+
+  context "destroy prevention" do
+    it "can be destroyed when on hand" do
+      inventory_unit = create(:inventory_unit, state: "on_hand")
+      expect(inventory_unit.destroy).to be_truthy
+      expect { inventory_unit.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "can be destroyed when backordered" do
+      inventory_unit = create(:inventory_unit, state: "backordered")
+      expect(inventory_unit.destroy).to be_truthy
+      expect { inventory_unit.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "cannot be destroyed when shipped" do
+      inventory_unit = create(:inventory_unit, state: "shipped")
+      expect(inventory_unit.destroy).to eq false
+      expect(inventory_unit.errors.full_messages.join).to match /Cannot destroy/
+      expect { inventory_unit.reload }.not_to raise_error
+    end
+
+    it "cannot be destroyed when returned" do
+      inventory_unit = create(:inventory_unit, state: "returned")
+      expect(inventory_unit.destroy).to eq false
+      expect(inventory_unit.errors.full_messages.join).to match /Cannot destroy/
+      expect { inventory_unit.reload }.not_to raise_error
+    end
+
+    it "cannot be destroyed if its shipment is ready" do
+      inventory_unit = create(:order_ready_to_ship).inventory_units.first
+      expect(inventory_unit.destroy).to eq false
+      expect(inventory_unit.errors.full_messages.join).to match /Cannot destroy/
+      expect { inventory_unit.reload }.not_to raise_error
+    end
+
+    it "cannot be destroyed if its shipment is shipped" do
+      inventory_unit = create(:shipped_order).inventory_units.first
+      expect(inventory_unit.destroy).to eq false
+      expect(inventory_unit.errors.full_messages.join).to match /Cannot destroy/
+      expect { inventory_unit.reload }.not_to raise_error
+    end
+  end
 end

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -15,7 +15,7 @@ describe Spree::ReturnAuthorization do
 
   context "save" do
     it "should be invalid when order has no inventory units" do
-      order.shipments.destroy_all
+      order.inventory_units.each(&:delete)
       return_authorization.save
       return_authorization.errors[:order].should == ["has no shipped units"]
     end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -615,4 +615,33 @@ describe Spree::Shipment do
       end
     end
   end
+
+  context "destroy prevention" do
+    it "can be destroyed when pending" do
+      shipment = create(:shipment, state: "pending")
+      expect(shipment.destroy).to be_truthy
+      expect { shipment.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "cannot be destroyed when ready" do
+      shipment = create(:shipment, state: "ready")
+      expect(shipment.destroy).to eq false
+      expect(shipment.errors.full_messages.join).to match /Cannot destroy/
+      expect { shipment.reload }.not_to raise_error
+    end
+
+    it "cannot be destroyed when shipped" do
+      shipment = create(:shipment, state: "shipped")
+      expect(shipment.destroy).to eq false
+      expect(shipment.errors.full_messages.join).to match /Cannot destroy/
+      expect { shipment.reload }.not_to raise_error
+    end
+
+    it "cannot be destroyed when canceled" do
+      shipment = create(:shipment, state: "canceled")
+      expect(shipment.destroy).to eq false
+      expect(shipment.errors.full_messages.join).to match /Cannot destroy/
+      expect { shipment.reload }.not_to raise_error
+    end
+  end
 end

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -12,8 +12,9 @@ describe Spree::ShippingRate do
   context "#display_price" do
     context "when tax included in price" do
       context "when the tax rate is from the default zone" do
+        before { shipment.order.update_attributes!(ship_address_id: nil) }
         let!(:zone) { create(:zone, :default_tax => true) }
-        let(:tax_rate) do 
+        let(:tax_rate) do
           create(:tax_rate,
             :name => "VAT",
             :amount => 0.1,

--- a/frontend/spec/features/order_spec.rb
+++ b/frontend/spec/features/order_spec.rb
@@ -6,7 +6,6 @@ describe 'orders' do
 
   before do
     order.update_attribute(:user_id, user.id)
-    order.shipments.destroy_all
     Spree::OrdersController.any_instance.stub(:try_spree_current_user => user)
   end
 


### PR DESCRIPTION
The checkout flow is fairly liberal with trying to destroy and rebuild shipments. This puts a few more checks in place to make sure that it doesn't destroy inventory units and shipments that we care about keeping around.