### PR TITLE
Destroy dependent join associations on model destroy.

### DIFF
--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -3,7 +3,7 @@ module Spree
     belongs_to :option_type, class_name: 'Spree::OptionType', touch: true, inverse_of: :option_values
     acts_as_list scope: :option_type
 
-    has_many :option_values_variants
+    has_many :option_values_variants, dependent: :destroy
     has_many :variants, through: :option_values_variants
 
     validates :name, :presentation, presence: true

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -16,7 +16,7 @@ module Spree
     has_many :stock_locations, through: :stock_items
     has_many :stock_movements
 
-    has_many :option_values_variants
+    has_many :option_values_variants, dependent: :destroy
     has_many :option_values, through: :option_values_variants
 
     has_many :images, -> { order(:position) }, as: :viewable, dependent: :destroy, class_name: "Spree::Image"


### PR DESCRIPTION
Destroying an option_value should destroy all join associations for that option_value. This prevents foreign key exceptions for situations where this may occur.