### PR TITLE
Fix issue where the response in case of an error was incorrect

### DIFF
--- a/api/app/controllers/spree/api/stock_transfers_controller.rb
+++ b/api/app/controllers/spree/api/stock_transfers_controller.rb
@@ -11,7 +11,7 @@ module Spree
         elsif @transfer_item.update_attributes(received_quantity: @transfer_item.received_quantity + 1)
           render 'spree/api/stock_transfers/receive', status: 200
         else
-          invalid_resource!(transfer_item)
+          invalid_resource!(@transfer_item)
         end
       end
     end

--- a/api/spec/controllers/spree/api/stock_transfers_controller_spec.rb
+++ b/api/spec/controllers/spree/api/stock_transfers_controller_spec.rb
@@ -46,6 +46,24 @@ module Spree
           end
         end
 
+        context "transfer item has been fully received" do
+          let(:variant_id) { transfer_item.variant.to_param }
+
+          before do
+            transfer_item.update_attributes!(expected_quantity: 1, received_quantity: 1)
+          end
+
+          it "returns a 422" do
+            subject
+            expect(response.status).to eq 422
+          end
+
+          it "returns a specific error message" do
+            subject
+            expect(JSON.parse(response.body)["errors"]["received_quantity"]).to eq ["must be less than or equal to 1"]
+          end
+        end
+
         context "variant is not in the transfer order" do
           let(:variant_id) { create(:variant).to_param }
 


### PR DESCRIPTION
The original error was “undefined local variable or method `transfer_item’”.