### PR TITLE
Increment stock when an item is returned to a location for which it does not yet have stock.

### DIFF
--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -176,15 +176,6 @@ module Spree
       self.update_attributes(acceptance_status_errors: validator.errors)
     end
 
-    def stock_item
-      return unless customer_return
-
-      Spree::StockItem.find_by({
-        variant_id: inventory_unit.variant_id,
-        stock_location_id: customer_return.stock_location_id,
-      })
-    end
-
     def currency
       return_authorization.try(:currency) || Spree::Config[:currency]
     end
@@ -192,8 +183,10 @@ module Spree
     def process_inventory_unit!
       inventory_unit.return!
 
-      Spree::StockMovement.create!(stock_item_id: stock_item.id, quantity: 1) if should_restock?
-      customer_return.process_return! if customer_return
+      if customer_return
+        customer_return.stock_location.restock(inventory_unit.variant, 1, customer_return) if should_restock?
+        customer_return.process_return!
+      end
     end
 
     def sibling_intended_for_exchange(status)
@@ -271,8 +264,8 @@ module Spree
     def should_restock?
       resellable? &&
         variant.should_track_inventory? &&
-        stock_item &&
-        stock_item.stock_location.restock_inventory?
+        customer_return &&
+        customer_return.stock_location.restock_inventory?
     end
   end
 end

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -77,12 +77,13 @@ describe Spree::ReturnItem do
     end
 
     context 'with a stock location' do
-      let(:stock_item)      { inventory_unit.find_stock_item }
+      let(:stock_location) { customer_return.stock_location }
+      let(:stock_item)      { stock_location.stock_item(inventory_unit.variant) }
 
       before do
         inventory_unit.update_attributes!(state: 'shipped')
         return_item.update_attributes!(reception_status: 'awaiting')
-        stock_item.stock_location.update_attributes!(restock_inventory: true)
+        stock_location.update_attributes!(restock_inventory: true)
       end
 
       it 'increases the count on hand' do
@@ -108,12 +109,24 @@ describe Spree::ReturnItem do
 
       context "when the stock location's restock_inventory is false" do
         before do
-          stock_item.stock_location.update_attributes!(restock_inventory: false)
+          stock_location.update_attributes!(restock_inventory: false)
         end
 
         it 'does not increase the count on hand' do
           expect { subject }.to_not change { stock_item.reload.count_on_hand }
         end
+      end
+
+      context "when the inventory unit's variant does not yet have a stock item for the stock location it was returned to" do
+        before { inventory_unit.variant.stock_items.destroy_all }
+
+        it "creates a new stock item for the inventory unit with a count of 1" do
+          expect { subject }.to change(Spree::StockItem, :count).by(1)
+          stock_item = Spree::StockItem.last
+          expect(stock_item.variant).to eq inventory_unit.variant
+          expect(stock_item.count_on_hand).to eq 1
+        end
+
       end
 
       Spree::ReturnItem::INTERMEDIATE_RECEPTION_STATUSES.each do |status|


### PR DESCRIPTION
Prior to this code, if an item is returned to a stock location that it
does not yet have a stock item for, it would not increment stock at that
stock location upon being received. This change creates a stock item for
the returned variant for the stock location if it doesn't yet exist.