### PR TITLE
Remove unused api attributes

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -129,7 +129,6 @@ module Spree
 
       @@creditcard_attributes = [
         :id, :month, :year, :cc_type, :last_digits, :name,
-        :gateway_customer_profile_id, :gateway_payment_profile_id
       ]
 
       @@user_attributes = [:id, :email, :created_at, :updated_at]


### PR DESCRIPTION
These don't seem like they need to be included by default and they
expose extra payment information.