### PR TITLE
Add an address to credit cards 

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -7,6 +7,7 @@ module Spree
 
     has_many :shipments, inverse_of: :address
     has_many :cartons, inverse_of: :address
+    has_many :credit_cards, inverse_of: :address
 
     validates :firstname, :lastname, :address1, :city, :country, presence: true
     validates :zipcode, presence: true, if: :require_zipcode?

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -2,6 +2,7 @@ module Spree
   class CreditCard < ActiveRecord::Base
     belongs_to :payment_method
     belongs_to :user, class_name: Spree.user_class, foreign_key: 'user_id'
+    belongs_to :address, inverse_of: :credit_cards
     has_many :payments, as: :source
 
     before_save :set_last_digits

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -89,6 +89,8 @@ module Spree
     before_create :link_by_email
     before_update :homogenize_line_item_currencies, if: :currency_changed?
 
+    after_save :sync_credit_card_addresses, if: :bill_address_id_changed?
+
     validates :email, presence: true, if: :require_email
     validates :email, email: true, if: :require_email, allow_blank: true
     validate :has_available_shipment
@@ -616,6 +618,14 @@ module Spree
 
       def set_currency
         self.currency = Spree::Config[:currency] if self[:currency].nil?
+      end
+
+      def sync_credit_card_addresses
+        if bill_address
+          credit_cards.each do |c|
+            c.update_attributes!(address: bill_address)
+          end
+        end
       end
 
   end

--- a/core/db/migrate/20150629175931_add_address_id_to_credit_card.rb
+++ b/core/db/migrate/20150629175931_add_address_id_to_credit_card.rb
@@ -1,0 +1,5 @@
+class AddAddressIdToCreditCard < ActiveRecord::Migration
+  def change
+    add_column :spree_credit_cards, :address_id, :integer
+  end
+end

--- a/core/db/migrate/20150630175644_copy_order_bill_address_to_credit_card.rb
+++ b/core/db/migrate/20150630175644_copy_order_bill_address_to_credit_card.rb
@@ -1,0 +1,12 @@
+class CopyOrderBillAddressToCreditCard < ActiveRecord::Migration
+  # Prevent everything from running in one giant transaction in postrgres.
+  disable_ddl_transaction!
+
+  def up
+    Rake::Task["spree:migrations:copy_order_bill_address_to_credit_card:up"].invoke
+  end
+
+  def down
+    Rake::Task["spree:migrations:copy_order_bill_address_to_credit_card:down"].invoke
+  end
+end

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :payment, class: Spree::Payment do
+  factory :payment, aliases: [:credit_card_payment], class: Spree::Payment do
     amount 45.75
     association(:payment_method, factory: :credit_card_payment_method)
     association(:source, factory: :credit_card)

--- a/core/lib/tasks/migrations/copy_order_bill_address_to_credit_card.rake
+++ b/core/lib/tasks/migrations/copy_order_bill_address_to_credit_card.rake
@@ -47,12 +47,11 @@ namespace 'spree:migrations:copy_order_bill_address_to_credit_card' do
   def postgres_copy
     batch_size = 10_000
 
-    last_id = Spree::CreditCard.last.try!(:id) || 0
-    puts "last id: #{last_id}"
+    puts "last id: #{last_credit_card_id}"
 
     current_start_id = 1
 
-    while current_start_id <= last_id
+    while current_start_id <= last_credit_card_id
       current_end_id = current_start_id + batch_size
       puts "updating #{current_start_id} to #{current_end_id}"
 
@@ -76,5 +75,9 @@ namespace 'spree:migrations:copy_order_bill_address_to_credit_card' do
 
       current_start_id += batch_size
     end
+  end
+
+  def last_credit_card_id
+    Spree::CreditCard.last.try!(:id) || 0
   end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -956,4 +956,23 @@ describe Spree::Order do
       expect(subject).not_to include order
     end
   end
+
+  describe 'credit card address syncing' do
+    let!(:order) { create(:order, bill_address: old_address) }
+    let!(:payment) { create(:payment, order: order, source: credit_card) }
+    let!(:credit_card) { create(:credit_card, address: old_address) }
+
+    let(:old_address) { create(:address) }
+    let(:new_address) { create(:address) }
+
+    context 'when the order bill address changes' do
+      it 'updates the credit card address' do
+        expect {
+          order.update_attributes!(bill_address: new_address)
+        }.to change {
+          credit_card.reload.address
+        }.from(old_address).to(new_address)
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -875,4 +875,32 @@ describe Spree::Payment do
       end
     end
   end
+
+  describe 'credit card address syncing' do
+    context 'when the order has an address' do
+      let(:credit_card) { create(:credit_card, address: old_address) }
+      let(:old_address) { create(:address) }
+      let(:order) { create(:order, bill_address: new_address) }
+      let(:new_address) { create(:address) }
+
+      it 'updates the credit card address' do
+        expect {
+          create(:payment, order: order, source: credit_card)
+        }.to change {
+          credit_card.address
+        }.from(old_address).to(new_address)
+      end
+    end
+
+    context 'when the order does not have a bill address' do
+      let(:credit_card) { create(:credit_card, address: old_address) }
+      let(:old_address) { create(:address) }
+      let(:order) { create(:order, bill_address: nil) }
+
+      it 'leaves the old credit card address in place' do
+        create(:payment, order: order, source: credit_card)
+        expect(credit_card.reload.address).to eq old_address
+      end
+    end
+  end
 end


### PR DESCRIPTION
(Update and rebase of https://github.com/bonobos/spree/pull/424/)

Update a credit card's address whenever:

- It is associated to a new order
- And order associated with the credit card updates its bill address

ActiveRecord callbacks were the most robust way we could think of to make this
happen.
